### PR TITLE
Refactor device mapping in SubsystemJson and example config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -162,5 +162,6 @@
       ],
       "url": "./src/main/resources/schemas/yams-shooter.schema.json"
     }
-  ]
+  ],
+  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
 }

--- a/src/main/deploy/basic_robot/subsystems/example.json
+++ b/src/main/deploy/basic_robot/subsystems/example.json
@@ -1,8 +1,17 @@
 {
   "devices": {
-    "percent_motor": "example/percent_motor.json",
-    "velocity_motor": "example/velocity_motor.json",
-    "yams_shooter": "example/yams_shooter.json"
+    "duty_cycle": {
+      "device": "percent_motor",
+      "file": "example/percent_motor.json"
+    },
+    "velocity_control": {
+      "device": "velocity_motor",
+      "file": "example/velocity_motor.json"
+    },
+    "shooter": {
+      "device": "yams_shooter",
+      "file": "example/yams_shooter.json"
+    }
   },
   "display": true
 }

--- a/src/main/java/org/frc5010/common/config/json/devices/SubsystemJson.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/SubsystemJson.java
@@ -9,8 +9,14 @@ import org.frc5010.common.arch.GenericSubsystem;
 
 /** The base JSON class for subsystem configurations */
 public class SubsystemJson {
+  public static class DeviceEntry {
+    public String device;
+    public String file;
+
+    public DeviceEntry() {}
+  }
   /** A map of device names and device configuration file names */
-  public Map<String, String> devices;
+  public Map<String, DeviceEntry> devices;
   /** Whether to display the subsystem in the dashboard */
   public boolean display = false;
   /** The logging level for the robot */
@@ -29,9 +35,9 @@ public class SubsystemJson {
   public void configureSubsystem(GenericSubsystem system, File directory)
       throws StreamReadException, DatabindException, IOException {
     for (String key : devices.keySet()) {
-      File deviceFile = new File(directory, devices.get(key));
+      File deviceFile = new File(directory, devices.get(key).file);
       assert deviceFile.exists();
-      DeviceConfigReader.readDeviceConfig(system, deviceFile, key);
+      DeviceConfigReader.readDeviceConfig(system, deviceFile, devices.get(key).device);
     }
   }
 }


### PR DESCRIPTION
Updated the device mapping in example.json to use objects with 'device' and 'file' fields instead of string values. Modified SubsystemJson.java to support the new structure with a DeviceEntry class and adjusted the configureSubsystem method accordingly. Also added Java language server VM arguments to .vscode/settings.json.