### PR TITLE
Add simulation option to view game pieces in vision

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -513,7 +513,82 @@
           "length": 0.15000000596046448,
           "width": 0.15000000596046448
         },
+        "GPA25": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA26": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA27": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA28": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA29": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
         "GPA3": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA30": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA31": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA32": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA33": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA34": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA35": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA36": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA37": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA38": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA39": {
           "image": ".\\pictures\\gpa.png",
           "length": 0.15000000596046448,
           "width": 0.15000000596046448
@@ -523,7 +598,62 @@
           "length": 0.15000000596046448,
           "width": 0.15000000596046448
         },
+        "GPA40": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA41": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA42": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA43": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA44": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA45": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA46": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA47": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA48": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA49": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
         "GPA5": {
+          "image": ".\\pictures\\gpa.png",
+          "length": 0.15000000596046448,
+          "width": 0.15000000596046448
+        },
+        "GPA50": {
           "image": ".\\pictures\\gpa.png",
           "length": 0.15000000596046448,
           "width": 0.15000000596046448

--- a/src/main/deploy/basic_robot/cameras.json
+++ b/src/main/deploy/basic_robot/cameras.json
@@ -4,5 +4,6 @@
     "localization.json",
     "shooter.json",
     "quest.json"
-  ]
+  ],
+  "viewGamePieces": false
 }

--- a/src/main/deploy/basic_robot/cameras/localization.json
+++ b/src/main/deploy/basic_robot/cameras/localization.json
@@ -2,7 +2,6 @@
   "name": "localization",
   "use": "apriltag",
   "type": "limelight",
-  "strategy": "LOWEST_AMBIGUITY",
   "column": 0,
   "x": -0.35,
   "y": -0.25,

--- a/src/main/java/org/frc5010/common/config/json/CameraConfigurationJson.java
+++ b/src/main/java/org/frc5010/common/config/json/CameraConfigurationJson.java
@@ -102,11 +102,39 @@ public class CameraConfigurationJson {
   public double fov = 70;
   /** Optional height of the target in meters (used for target tracking mode) */
   public double targetHeight = 0;
+  /** Whether to view game pieces in simulation */
+  public boolean viewGamePieces = true;
   /**
    * Optional array of AprilTag fiducial IDs to track. If empty, all AprilTags may be detected
    * depending on the configuration strategy.
    */
   public int[] targetFiducialIds = new int[0];
+
+  /**
+   * Sets whether to view game pieces in simulation. If true, the camera system will simulate vision
+   * targets for game pieces in the arena. This can be useful for testing vision code without a real
+   * camera. If false, the camera system will only process vision information for real camera
+   * images.
+   *
+   * @param viewGamePieces whether to enable or disable viewing game pieces in simulation
+   */
+  public void setViewGamePieces(boolean viewGamePieces) {
+    this.viewGamePieces = viewGamePieces;
+  }
+
+  /**
+   * Returns whether the camera system can view game pieces in simulation mode.
+   *
+   * <p>This property is set by the {@link #setViewGamePieces(boolean)} method and controls whether
+   * the camera system will simulate vision targets for game pieces in the arena. If true, the
+   * camera system will simulate game pieces in simulation; otherwise, it will only process vision
+   * information for real camera images.
+   *
+   * @return whether the camera system can view game pieces in simulation mode
+   */
+  public boolean canViewGamePieces() {
+    return viewGamePieces;
+  }
 
   /**
    * Configures the camera system based on the provided robot and current configuration.
@@ -171,7 +199,6 @@ public class CameraConfigurationJson {
                         name,
                         column,
                         AprilTags.aprilTagFieldLayout,
-                        PoseStrategy.valueOf(strategy),
                         robotToCamera,
                         robot.getPoseSupplier(),
                         targetFiducialIdList);
@@ -181,7 +208,6 @@ public class CameraConfigurationJson {
                         name,
                         column,
                         AprilTags.aprilTagFieldLayout,
-                        PoseStrategy.valueOf(strategy),
                         robotToCamera,
                         robot.getPoseSupplier());
               }
@@ -195,7 +221,6 @@ public class CameraConfigurationJson {
                       name,
                       column,
                       AprilTags.aprilTagFieldLayout,
-                      PoseStrategy.valueOf(strategy),
                       robotToCamera,
                       robot.getPoseSupplier(),
                       targetFiducialIdList);
@@ -233,7 +258,6 @@ public class CameraConfigurationJson {
                   name,
                   column,
                   AprilTags.aprilTagFieldLayout,
-                  PoseStrategy.valueOf(strategy),
                   robotToCamera,
                   robot.getSimulatedPoseSupplier(),
                   width,
@@ -250,7 +274,6 @@ public class CameraConfigurationJson {
                 name,
                 column,
                 AprilTags.aprilTagFieldLayout,
-                PoseStrategy.LOWEST_AMBIGUITY,
                 robotToCamera,
                 robot.getSimulatedPoseSupplier(),
                 targetFiducialIdList,
@@ -263,7 +286,6 @@ public class CameraConfigurationJson {
                 name,
                 column,
                 AprilTags.aprilTagFieldLayout,
-                PoseStrategy.LOWEST_AMBIGUITY,
                 robotToCamera,
                 robot.getSimulatedPoseSupplier(),
                 width,
@@ -275,13 +297,15 @@ public class CameraConfigurationJson {
                 name,
                 column,
                 AprilTags.aprilTagFieldLayout,
-                PoseStrategy.LOWEST_AMBIGUITY,
                 robotToCamera,
                 robot.getSimulatedPoseSupplier(),
                 width,
                 height,
                 fov);
       }
+    }
+    if (null != camera) {
+      camera.setCanViewGamePieces(viewGamePieces);
     }
     switch (use) {
       case "target":

--- a/src/main/java/org/frc5010/common/config/json/VisionPropertiesJson.java
+++ b/src/main/java/org/frc5010/common/config/json/VisionPropertiesJson.java
@@ -25,6 +25,7 @@ public class VisionPropertiesJson {
   public String aprilTagLayout = "default";
   public String simulatedField = "default";
   public Map<String, String[]> gamePieces = new HashMap<>();
+  public boolean viewGamePieces = true;
 
   /**
    * Creates cameras for a given robot using the provided map of camera configurations.
@@ -103,6 +104,7 @@ public class VisionPropertiesJson {
       assert cameraFile.exists();
       CameraConfigurationJson camera =
           new ObjectMapper().readValue(cameraFile, CameraConfigurationJson.class);
+      camera.setViewGamePieces(viewGamePieces);
       camerasMap.put(camera.name, camera);
     }
     return camerasMap;

--- a/src/main/java/org/frc5010/common/drive/GenericDrivetrain.java
+++ b/src/main/java/org/frc5010/common/drive/GenericDrivetrain.java
@@ -28,6 +28,7 @@ import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -264,8 +265,8 @@ public abstract class GenericDrivetrain extends GenericSubsystem {
     int count = 0;
     List<Pose3d> gpas =
         SimulatedArena.getInstance().getGamePiecesByType(Constants.Simulation.gamePieceA).stream()
+            .sorted(Comparator.comparingDouble(it -> it.getPose3d().getX() + it.getPose3d().getY()))
             .map(it -> it.getPose3d())
-            .limit(24)
             .collect(Collectors.toList());
     for (Pose3d gpa : gpas) {
       getField2d()
@@ -280,7 +281,6 @@ public abstract class GenericDrivetrain extends GenericSubsystem {
     List<Pose3d> gpbs =
         SimulatedArena.getInstance().getGamePiecesByType(Constants.Simulation.gamePieceB).stream()
             .map(it -> it.getPose3d())
-            .limit(24)
             .collect(Collectors.toList());
     for (Pose3d gpb : gpbs) {
       getField2d()
@@ -302,8 +302,9 @@ public abstract class GenericDrivetrain extends GenericSubsystem {
       int count = 0;
       for (Pose3d gpa :
           SimulatedArena.getInstance().getGamePiecesByType(Constants.Simulation.gamePieceA).stream()
+              .sorted(
+                  Comparator.comparingDouble(it -> it.getPose3d().getX() + it.getPose3d().getY()))
               .map(it -> it.getPose3d())
-              .limit(24)
               .collect(Collectors.toList())) {
         getField2d()
             .getObject("CARPET" + count)
@@ -317,7 +318,6 @@ public abstract class GenericDrivetrain extends GenericSubsystem {
       for (Pose3d gpb :
           SimulatedArena.getInstance().getGamePiecesByType(Constants.Simulation.gamePieceB).stream()
               .map(it -> it.getPose3d())
-              .limit(24)
               .collect(Collectors.toList())) {
         getField2d()
             .getObject("CARPET" + count)

--- a/src/main/java/org/frc5010/common/sensors/camera/GenericCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/GenericCamera.java
@@ -30,6 +30,8 @@ public abstract class GenericCamera implements PoseProvider {
   protected int colIndex;
   /** The name of the camera */
   protected String name;
+  /** Whether or not to view the game pieces in simulation */
+  protected boolean canViewGamePieces = true;
 
   /**
    * Create a new camera
@@ -146,6 +148,24 @@ public abstract class GenericCamera implements PoseProvider {
    * @return the area of the target
    */
   public abstract double getTargetArea();
+
+  /**
+   * Returns whether or not the camera can view game pieces in simulation mode.
+   *
+   * @return whether or not the camera can view game pieces in simulation mode
+   */
+  public boolean canViewGamePieces() {
+    return canViewGamePieces;
+  }
+
+  /**
+   * Sets whether or not the camera should view game pieces in simulation mode.
+   *
+   * @param canViewGamePieces whether or not the camera should view game pieces in simulation mode
+   */
+  public void setCanViewGamePieces(boolean canViewGamePieces) {
+    this.canViewGamePieces = canViewGamePieces;
+  }
 
   /**
    * A method to get the distance to the target.

--- a/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionFiducialTargetCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionFiducialTargetCamera.java
@@ -12,7 +12,6 @@ import edu.wpi.first.math.geometry.Transform3d;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
 /** A camera using the PhotonVision library. */
 public class PhotonVisionFiducialTargetCamera extends PhotonVisionPoseCamera {
@@ -32,11 +31,10 @@ public class PhotonVisionFiducialTargetCamera extends PhotonVisionPoseCamera {
       String name,
       int colIndex,
       AprilTagFieldLayout fieldLayout,
-      PoseStrategy strategy,
       Transform3d cameraToRobot,
       Supplier<Pose2d> poseSupplier,
       List<Integer> fiducialIds) {
-    super(name, colIndex, fieldLayout, strategy, cameraToRobot, poseSupplier, fiducialIds);
+    super(name, colIndex, fieldLayout, cameraToRobot, poseSupplier, fiducialIds);
     this.fieldLayout = fieldLayout;
     targetFiducialIds = fiducialIds;
   }

--- a/src/main/java/org/frc5010/common/sensors/camera/SimulatedCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/SimulatedCamera.java
@@ -48,13 +48,12 @@ public class SimulatedCamera extends PhotonVisionPoseCamera {
       String name,
       int colIndex,
       AprilTagFieldLayout fieldLayout,
-      PoseStrategy strategy,
       Transform3d cameraToRobot,
       Supplier<Pose2d> poseSupplier,
       int width,
       int height,
       double fov) {
-    super(name, colIndex, fieldLayout, strategy, cameraToRobot, poseSupplier);
+    super(name, colIndex, fieldLayout, cameraToRobot, poseSupplier);
     if (!tagsLoaded) {
       visionSim.addAprilTags(fieldLayout);
       tagsLoaded = true;
@@ -131,7 +130,7 @@ public class SimulatedCamera extends PhotonVisionPoseCamera {
       PoseStrategy strategy,
       Transform3d cameraToRobot,
       Supplier<Pose2d> poseSupplier) {
-    this(name, colIndex, fieldLayout, strategy, cameraToRobot, poseSupplier, 640, 480, 70.0);
+    this(name, colIndex, fieldLayout, cameraToRobot, poseSupplier, 640, 480, 70.0);
   }
 
   /** Update the simulated camera */

--- a/src/main/java/org/frc5010/common/sensors/camera/SimulatedFiducialTargetCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/SimulatedFiducialTargetCamera.java
@@ -12,7 +12,6 @@ import edu.wpi.first.math.geometry.Transform3d;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
 /** A simulated camera using the PhotonVision library. */
 public class SimulatedFiducialTargetCamera extends SimulatedCamera {
@@ -37,14 +36,13 @@ public class SimulatedFiducialTargetCamera extends SimulatedCamera {
       String name,
       int colIndex,
       AprilTagFieldLayout fieldLayout,
-      PoseStrategy strategy,
       Transform3d cameraToRobot,
       Supplier<Pose2d> poseSupplier,
       List<Integer> fiducialIds,
       int width,
       int height,
       double fov) {
-    super(name, colIndex, fieldLayout, strategy, cameraToRobot, poseSupplier, width, height, fov);
+    super(name, colIndex, fieldLayout, cameraToRobot, poseSupplier, width, height, fov);
     targetFiducialIds = fiducialIds;
     visionLayout.addDouble("Target ID", () -> target.map(it -> it.getFiducialId()).orElse(-1));
   }

--- a/src/main/java/org/frc5010/common/sensors/camera/SimulatedVisualTargetCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/SimulatedVisualTargetCamera.java
@@ -9,7 +9,6 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Transform3d;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
 /** A simulated camera using the PhotonVision library. */
 public class SimulatedVisualTargetCamera extends SimulatedCamera {
@@ -31,13 +30,12 @@ public class SimulatedVisualTargetCamera extends SimulatedCamera {
       String name,
       int colIndex,
       AprilTagFieldLayout fieldLayout,
-      PoseStrategy strategy,
       Transform3d cameraToRobot,
       Supplier<Pose2d> poseSupplier,
       int width,
       int height,
       double fov) {
-    super(name, colIndex, fieldLayout, strategy, cameraToRobot, poseSupplier, width, height, fov);
+    super(name, colIndex, fieldLayout, cameraToRobot, poseSupplier, width, height, fov);
   }
 
   /** Update the simulated camera */

--- a/src/main/java/org/frc5010/common/subsystems/CameraSystem.java
+++ b/src/main/java/org/frc5010/common/subsystems/CameraSystem.java
@@ -52,6 +52,8 @@ public abstract class CameraSystem extends GenericSubsystem {
   protected DisplayBoolean HAS_VALID_TARGET;
   /** Target model used for vision simulation (default: 12-inch diameter circle at ~0.3556m) */
   protected TargetModel targetModel = new TargetModel(0.3556);
+  /** Whether to view game pieces in simulation */
+  protected boolean viewGamePieces = true;
 
   /**
    * Creates a new CameraSystem with the specified camera.
@@ -83,11 +85,13 @@ public abstract class CameraSystem extends GenericSubsystem {
 
   @Override
   public void simulationPeriodic() {
+    if (!camera.canViewGamePieces()) {
+      return;
+    }
     // Update game piece A targets in simulation
     List<Pose3d> gpas =
         SimulatedArena.getInstance().getGamePiecesByType(Constants.Simulation.gamePieceA).stream()
             .map(it -> it.getPose3d())
-            .limit(24)
             .collect(Collectors.toList());
     SimulatedCamera.visionSim.removeVisionTargets("GPA");
     for (Pose3d gpa : gpas) {
@@ -98,13 +102,24 @@ public abstract class CameraSystem extends GenericSubsystem {
     List<Pose3d> gpbs =
         SimulatedArena.getInstance().getGamePiecesByType(Constants.Simulation.gamePieceB).stream()
             .map(it -> it.getPose3d())
-            .limit(24)
             .collect(Collectors.toList());
     SimulatedCamera.visionSim.removeVisionTargets("GPB");
     for (Pose3d gpb : gpbs) {
       VisionTargetSim simTarget = new VisionTargetSim(gpb, targetModel);
       SimulatedCamera.visionSim.addVisionTargets("GPB", simTarget);
     }
+  }
+
+  /**
+   * Enables or disables the camera from viewing game pieces in simulation. When enabled, the camera
+   * will simulate vision targets for game pieces in the arena. This can be useful for testing
+   * vision code without a real camera. When disabled, the camera will only process vision
+   * information for real camera images.
+   *
+   * @param viewGamePieces whether to enable or disable viewing game pieces in simulation
+   */
+  public void setViewGamePieces(boolean viewGamePieces) {
+    this.viewGamePieces = viewGamePieces;
   }
 
   /**


### PR DESCRIPTION
Introduces a 'viewGamePieces' property to camera and vision configuration, allowing cameras to optionally simulate game piece vision targets. Updates related classes to respect this setting, removes hardcoded pose strategy usage, and improves sorting and display logic for simulated game pieces.