### PR TITLE
Refactor robot mode lifecycle and button binding methods

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -132,7 +132,7 @@ public class Robot extends LoggedRobot {
   /** This function is called once each time the robot enters Disabled mode. */
   @Override
   public void disabledInit() {
-    m_robotContainer.disabledBehavior();
+    m_robotContainer.disabledInit();
     disabledTimer.reset();
     disabledTimer.start();
   }
@@ -140,7 +140,7 @@ public class Robot extends LoggedRobot {
   @Override
   public void disabledPeriodic() {
     if (disabledTimer.hasElapsed(Constants.DrivebaseConstants.WHEEL_LOCK_TIME)) {
-      m_robotContainer.disabledBehavior();
+      m_robotContainer.disabledPeriodic();
       disabledTimer.stop();
     }
   }
@@ -149,6 +149,7 @@ public class Robot extends LoggedRobot {
   @Override
   public void autonomousInit() {
     m_autonomousCommand = m_robotContainer.getAutonomousCommand();
+    m_robotContainer.setupDefaults();
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
@@ -171,6 +172,7 @@ public class Robot extends LoggedRobot {
     } else {
       CommandScheduler.getInstance().cancelAll();
     }
+    m_robotContainer.configureButtonBindings();
     m_robotContainer.setupDefaults();
   }
 
@@ -182,7 +184,8 @@ public class Robot extends LoggedRobot {
   public void testInit() {
     // Cancels all running commands at the start of test mode.
     CommandScheduler.getInstance().cancelAll();
-    m_robotContainer.setupDefaults();
+    m_robotContainer.configureAltButtonBindings();
+    m_robotContainer.setupAltDefaultCommands();
   }
 
   /** This function is called periodically during test mode. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -22,17 +22,32 @@ public class RobotContainer implements WpiHelperInterface {
     robot = robotsParser.getRobot();
 
     initAutoCommands();
-    configureButtonBindings();
     WpiNetworkTableValuesHelper.loadRegisteredToNetworkTables();
   }
 
-  private void configureButtonBindings() {
+  /**
+   * Configures the button bindings for the robot. This should be called from the robot periodic
+   * methods (i.e. robotPeriodic) to update the button bindings.
+   */
+  public void configureButtonBindings() {
     robot.configureButtonBindings();
+  }
+
+  public void disabledInit() {
+    robot.disabledInit();
+  }
+
+  public void configureAltButtonBindings() {
+    robot.configureAltButtonBindings();
   }
 
   // Just sets up defalt commands (setUpDeftCom)
   public void setupDefaults() {
     robot.setupDefaultCommands();
+  }
+
+  public void setupAltDefaultCommands() {
+    robot.setupAltDefaultCommands();
   }
 
   /**
@@ -48,7 +63,7 @@ public class RobotContainer implements WpiHelperInterface {
     robot.buildAutoCommands();
   }
 
-  public void disabledBehavior() {
-    robot.disabledBehavior();
+  public void disabledPeriodic() {
+    robot.disabledPeriodic();
   }
 }

--- a/src/main/java/org/frc5010/common/arch/GenericMechanism.java
+++ b/src/main/java/org/frc5010/common/arch/GenericMechanism.java
@@ -50,6 +50,14 @@ public abstract class GenericMechanism implements WpiHelperInterface {
   public abstract void configureButtonBindings(Controller driver, Controller operator);
 
   /**
+   * configureAltButtonBindings should map button/axis controls to commands
+   *
+   * @param driver - driver joystick
+   * @param operator - operator joystick
+   */
+  public void configureAltButtonBindings(Controller driver, Controller operator) {}
+
+  /**
    * setupDefaultCommands should setup the default commands needed by subsystems It could check for
    * Test mode and enable different commands
    *
@@ -64,7 +72,7 @@ public abstract class GenericMechanism implements WpiHelperInterface {
    * @param driver the driver controller
    * @param operator the operator controller
    */
-  public void setupTestDefaultCommmands(Controller driver, Controller operator) {}
+  public void setupAltDefaultCommmands(Controller driver, Controller operator) {}
 
   /**
    * initRealOrSim should check the real or simulation state of the robot and initialize its code
@@ -87,5 +95,8 @@ public abstract class GenericMechanism implements WpiHelperInterface {
   public abstract Command generateAutoCommand(Command autoCommand);
 
   /** Executed periodically when robot is disabled */
-  public void disabledBehavior() {}
+  public void disabledInit() {}
+
+  /** Executed periodically when robot is disabled */
+  public void disabledPeriodic() {}
 }

--- a/src/main/java/org/frc5010/common/arch/GenericRobot.java
+++ b/src/main/java/org/frc5010/common/arch/GenericRobot.java
@@ -194,6 +194,16 @@ public abstract class GenericRobot extends GenericMechanism implements GenericDe
   }
 
   /**
+   * Use this method to define your button->command mappings. Buttons can be created by
+   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
+   * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
+   */
+  public void configureAltButtonBindings() {
+    configureAltButtonBindings(driver.orElse(null), operator.orElse(null));
+  }
+
+  /**
    * Sets up the default commands for the robot. If the robot is in teleoperated or autonomous mode,
    * it will call the setupDefaultCommands method. If the robot is in test mode, it will call the
    * setupTestDefaultCommands method.
@@ -202,7 +212,13 @@ public abstract class GenericRobot extends GenericMechanism implements GenericDe
     if (DriverStation.isTeleop() || DriverStation.isAutonomous()) {
       setupDefaultCommands(driver.orElse(null), operator.orElse(null));
     } else if (DriverStation.isTest()) {
-      setupTestDefaultCommmands(driver.orElse(null), operator.orElse(null));
+      setupAltDefaultCommmands(driver.orElse(null), operator.orElse(null));
+    }
+  }
+
+  public void setupAltDefaultCommands() {
+    if (DriverStation.isTest()) {
+      setupAltDefaultCommmands(driver.orElse(null), operator.orElse(null));
     }
   }
 
@@ -250,7 +266,7 @@ public abstract class GenericRobot extends GenericMechanism implements GenericDe
 
   /** Executes periodic behavior when the robot is disabled. */
   @Override
-  public void disabledBehavior() {
+  public void disabledPeriodic() {
     selectableCommand.periodic();
   }
 


### PR DESCRIPTION
Renames and restructures disabled and periodic methods for clarity, splitting 'disabledBehavior' into 'disabledInit' and 'disabledPeriodic'. Adds alternate button binding and default command setup methods for test mode. Updates method calls in Robot and RobotContainer to use the new structure, improving code organization and lifecycle handling.