### PR TITLE
Add NeoVortex motor to MotorConstants

### DIFF
--- a/src/main/java/org/frc5010/common/motors/MotorConstants.java
+++ b/src/main/java/org/frc5010/common/motors/MotorConstants.java
@@ -21,6 +21,11 @@ public class MotorConstants {
         RPM.of(11000),
         (Integer numberOfMotors) -> DCMotor.getNeo550(numberOfMotors),
         42),
+    NeoVortex(
+        Amps.of(40),
+        RPM.of(6000),
+        (Integer numberOfMotors) -> DCMotor.getNeoVortex(numberOfMotors),
+        42),
     KrakenX60(
         Amps.of(40),
         RPM.of(6000),


### PR DESCRIPTION
Introduce a NeoVortex enum entry in src/main/java/org/frc5010/common/motors/MotorConstants.java to support the NeoVortex motor. The entry uses Amps.of(40), RPM.of(6000), the DCMotor.getNeoVortex(numberOfMotors) factory, and the existing 42 parameter.