### PR TITLE
Add turret sysid and gearStages support

### DIFF
--- a/src/main/deploy/basic_robot/subsystems/example.json
+++ b/src/main/deploy/basic_robot/subsystems/example.json
@@ -17,7 +17,7 @@
       "file": "example/yams_arm.json"
     },
     {
-      "device": "yams_pivot",
+      "device": "yams_turret",
       "file": "example/yams_pivot.json"
     }
   ]

--- a/src/main/deploy/basic_robot/subsystems/example/yams_pivot.json
+++ b/src/main/deploy/basic_robot/subsystems/example/yams_pivot.json
@@ -21,7 +21,8 @@
         "val": 0.0,
         "uom": "deg"
       }
-    }
+    },
+    "movementPlane": "XY"
   },
   "motorSystemId": {
     "feedBack": {
@@ -33,6 +34,14 @@
       "s": 0.0,
       "v": 0.0,
       "a": 0.0
+    },
+    "maxVelocity": {
+      "val": 180,
+      "uom": "deg/s"
+    },
+    "maxAcceleration": {
+      "val": 90,
+      "uom": "deg/s^2"
     }
   },
   "simSystemId": {
@@ -45,26 +54,43 @@
       "s": 0.0,
       "v": 0.0,
       "a": 0.0
+    },
+    "maxVelocity": {
+      "val": 180,
+      "uom": "deg/s"
+    },
+    "maxAcceleration": {
+      "val": 90,
+      "uom": "deg/s^2"
     }
   },
+  "lowerHardLimit": {
+    "val": -165,
+    "uom": "deg"
+  },
+  "upperHardLimit": {
+    "val": 165,
+    "uom": "deg"
+  },
+  "startingAngle": {
+    "val": 0,
+    "uom": "deg"
+  },
   "lowerSoftLimit": {
-    "val": -5000,
-    "uom": "rpm"
+    "val": -160,
+    "uom": "deg"
   },
   "upperSoftLimit": {
-    "val": 5000,
-    "uom": "rpm"
+    "val": 160,
+    "uom": "deg"
   },
-  "gearing": [
-    3,
-    4
-  ],
-  "mass": {
-    "val": 5,
-    "uom": "lbs"
-  },
+  "gearStages": "12:36:40:12:108",
   "radius": {
-    "val": 1.925,
+    "val": 5,
     "uom": "in"
+  },
+  "mass": {
+    "val": 20,
+    "uom": "lb"
   }
 }

--- a/src/main/java/frc/robot/example/commands/ExampleCommands.java
+++ b/src/main/java/frc/robot/example/commands/ExampleCommands.java
@@ -71,6 +71,8 @@ public class ExampleCommands {
     driver.createLeftBumper().onTrue(shouldShootCommand()).onFalse(shouldPrepCommand());
     driver.createAButton().onTrue(shouldIntakeCommand()).onFalse(shouldUseLowSpeed());
 
+    driver.createBButton().whileTrue(launcher.sysIdPivot());
+
     lowState.switchTo(prepState).when(() -> requestedState == LauncherState.PREP_SHOOT);
     prepState.switchTo(lowState).when(() -> requestedState == LauncherState.LOW_SPEED);
 

--- a/src/main/java/frc/robot/example/subsystems/ExampleIO.java
+++ b/src/main/java/frc/robot/example/subsystems/ExampleIO.java
@@ -65,6 +65,12 @@ public interface ExampleIO {
 
   public Command sysIdShooter();
 
+  public Command sysIdArm();
+
+  public Command sysIdPivot();
+
+  public Command sysIdTurret();
+
   public default Command addBallToRobot() {
     return Commands.none();
   }

--- a/src/main/java/frc/robot/example/subsystems/ExampleIOReal.java
+++ b/src/main/java/frc/robot/example/subsystems/ExampleIOReal.java
@@ -4,6 +4,9 @@
 
 package frc.robot.example.subsystems;
 
+import static edu.wpi.first.units.Units.Seconds;
+import static edu.wpi.first.units.Units.Volts;
+
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -15,6 +18,7 @@ import org.frc5010.common.motors.function.AngularControlMotor;
 import org.frc5010.common.motors.function.PercentControlMotor;
 import org.frc5010.common.motors.function.VelocityControlMotor;
 import yams.mechanisms.positional.Arm;
+import yams.mechanisms.positional.Pivot;
 import yams.mechanisms.velocity.FlyWheel;
 
 /** Add your docs here. */
@@ -26,6 +30,7 @@ public class ExampleIOReal implements ExampleIO {
   protected FlyWheel shooter;
   protected Arm arm;
   protected GenericSubsystem parent;
+  protected Pivot pivot;
 
   public ExampleIOReal(Map<String, Object> devices, GenericSubsystem parent) {
     this.devices = devices;
@@ -34,6 +39,7 @@ public class ExampleIOReal implements ExampleIO {
     this.controlledMotor = (VelocityControlMotor) devices.get("velocity_motor");
     this.shooter = (FlyWheel) devices.get("Shooter");
     this.arm = (Arm) devices.get("Hood");
+    this.pivot = (Pivot) devices.get("Turret");
     this.angularMotor = (AngularControlMotor) devices.get("angular_motor");
   }
 
@@ -82,6 +88,23 @@ public class ExampleIOReal implements ExampleIO {
         5,
         3,
         3);
+  }
+
+  public Command sysIdTurret() {
+    return SystemIdentification.getSysIdFullCommand(
+        SystemIdentification.angleSysIdRoutine(
+            pivot.getMotorController(), parent.getName(), parent),
+        5,
+        3,
+        3);
+  }
+
+  public Command sysIdArm() {
+    return arm.sysId(Volts.of(12), Volts.of(1).per(Seconds), Seconds.of(10));
+  }
+
+  public Command sysIdPivot() {
+    return pivot.sysId(Volts.of(12), Volts.of(1).per(Seconds), Seconds.of(10));
   }
 
   public Command launchBall() {

--- a/src/main/java/frc/robot/example/subsystems/ExampleSubsystem.java
+++ b/src/main/java/frc/robot/example/subsystems/ExampleSubsystem.java
@@ -76,6 +76,18 @@ public class ExampleSubsystem extends GenericSubsystem {
     return io.launchBall();
   }
 
+  public Command sysIdArm() {
+    return io.sysIdArm();
+  }
+
+  public Command sysIdPivot() {
+    return io.sysIdPivot();
+  }
+
+  public Command sysIdTurret() {
+    return io.sysIdTurret();
+  }
+
   @Override
   public void periodic() {
     super.periodic();

--- a/src/main/java/org/frc5010/common/config/json/devices/YamsArmConfigurationJson.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/YamsArmConfigurationJson.java
@@ -33,6 +33,7 @@ public class YamsArmConfigurationJson implements DeviceConfiguration {
   public UnitValueJson lowerSoftLimit = new UnitValueJson(0, AngleUnit.DEGREES.toString());
   public UnitValueJson upperSoftLimit = new UnitValueJson(0, AngleUnit.DEGREES.toString());
   public double[] gearing;
+  public String gearStages = "";
   public UnitValueJson mass = new UnitValueJson(0, MassUnit.POUNDS.toString());
   public UnitValueJson voltageCompensation = new UnitValueJson(12, VoltageUnit.VOLTS.toString());
   public UnitValueJson horizontalZero = new UnitValueJson(0, AngleUnit.DEGREES.toString());
@@ -63,7 +64,8 @@ public class YamsArmConfigurationJson implements DeviceConfiguration {
                     simSystemId.feedForward.a));
 
     YamsConfigCommon.PhysicalParameters physicalParams =
-        new YamsConfigCommon.PhysicalParameters(voltageCompensation, mass, length, gearing);
+        new YamsConfigCommon.PhysicalParameters(
+            voltageCompensation, mass, length, gearing, gearStages);
 
     Optional<SmartMotorController> smartMotor =
         YamsConfigCommon.configureSmartMotorController(

--- a/src/main/java/org/frc5010/common/config/json/devices/YamsConfigCommon.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/YamsConfigCommon.java
@@ -36,11 +36,16 @@ public class YamsConfigCommon {
         UnitValueJson voltageCompensation,
         UnitValueJson mass,
         UnitValueJson length,
-        double[] gearing) {
+        double[] gearing,
+        String gearStages) {
       this.voltageCompensation = UnitsParser.parseVolts(voltageCompensation);
       this.mass = UnitsParser.parseMass(mass);
       this.length = UnitsParser.parseDistance(length);
-      this.gearing = new MechanismGearing(GearBox.fromReductionStages(gearing));
+      if (!gearStages.isEmpty()) {
+        this.gearing = new MechanismGearing(GearBox.fromStages(gearStages));
+      } else { // gearStages is empty, so use gearing array
+        this.gearing = new MechanismGearing(GearBox.fromReductionStages(gearing));
+      }
     }
   }
 

--- a/src/main/java/org/frc5010/common/config/json/devices/YamsElevatorConfigurationJson.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/YamsElevatorConfigurationJson.java
@@ -31,6 +31,7 @@ public class YamsElevatorConfigurationJson implements DeviceConfiguration {
   public UnitValueJson lowerHardLimit = new UnitValueJson(0, DistanceUnit.METERS.toString());
   public UnitValueJson upperHardLimit = new UnitValueJson(0, DistanceUnit.METERS.toString());
   public double[] gearing;
+  public String gearStages = "";
   public UnitValueJson startingPosition = new UnitValueJson(0, DistanceUnit.METERS.toString());
   public UnitValueJson mass = new UnitValueJson(0, MassUnit.POUNDS.toString());
   public UnitValueJson voltageCompensation = new UnitValueJson(12, VoltageUnit.VOLTS.toString());
@@ -69,7 +70,8 @@ public class YamsElevatorConfigurationJson implements DeviceConfiguration {
                 simSystemId.feedForward.a));
 
     YamsConfigCommon.PhysicalParameters physicalParams =
-        new YamsConfigCommon.PhysicalParameters(voltageCompensation, mass, drumRadius, gearing);
+        new YamsConfigCommon.PhysicalParameters(
+            voltageCompensation, mass, drumRadius, gearing, gearStages);
 
     Optional<SmartMotorController> smartMotor =
         YamsConfigCommon.configureSmartMotorController(

--- a/src/main/java/org/frc5010/common/config/json/devices/YamsPivotConfigurationJson.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/YamsPivotConfigurationJson.java
@@ -34,6 +34,7 @@ public class YamsPivotConfigurationJson implements DeviceConfiguration {
   public UnitValueJson lowerSoftLimit = new UnitValueJson(0, AngleUnit.DEGREES.toString());
   public UnitValueJson upperSoftLimit = new UnitValueJson(0, AngleUnit.DEGREES.toString());
   public double[] gearing;
+  public String gearStages = "";
   public UnitValueJson voltageCompensation = new UnitValueJson(12, VoltageUnit.VOLTS.toString());
   public UnitValueJson radius = new UnitValueJson(1, DistanceUnit.INCHES.toString());
   public UnitValueJson mass = new UnitValueJson(1, MassUnit.POUNDS.toString());
@@ -63,7 +64,8 @@ public class YamsPivotConfigurationJson implements DeviceConfiguration {
             .withControlMode(ControlMode.valueOf(motorSystemId.controlMode));
 
     YamsConfigCommon.PhysicalParameters physicalParams =
-        new YamsConfigCommon.PhysicalParameters(voltageCompensation, mass, radius, gearing);
+        new YamsConfigCommon.PhysicalParameters(
+            voltageCompensation, mass, radius, gearing, gearStages);
 
     Optional<SmartMotorController> smartMotor =
         YamsConfigCommon.configureSmartMotorController(

--- a/src/main/java/org/frc5010/common/config/json/devices/YamsShooterConfigurationJson.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/YamsShooterConfigurationJson.java
@@ -33,6 +33,7 @@ public class YamsShooterConfigurationJson implements DeviceConfiguration {
   public UnitValueJson upperSoftLimit =
       new UnitValueJson(0, AngularVelocityUnit.DEGREES_PER_SECOND.toString());
   public double[] gearing;
+  public String gearStages = "";
   public UnitValueJson voltageCompensation = new UnitValueJson(12, VoltageUnit.VOLTS.toString());
   public UnitValueJson mass = new UnitValueJson(0, MassUnit.POUNDS.toString());
   public UnitValueJson radius = new UnitValueJson(0, DistanceUnit.INCHES.toString());
@@ -59,7 +60,8 @@ public class YamsShooterConfigurationJson implements DeviceConfiguration {
                     simSystemId.feedForward.a))
             .withControlMode(ControlMode.valueOf(motorSystemId.controlMode));
     YamsConfigCommon.PhysicalParameters physicalParams =
-        new YamsConfigCommon.PhysicalParameters(voltageCompensation, mass, radius, gearing);
+        new YamsConfigCommon.PhysicalParameters(
+            voltageCompensation, mass, radius, gearing, gearStages);
 
     Optional<SmartMotorController> smartMotor =
         YamsConfigCommon.configureSmartMotorController(

--- a/src/main/java/org/frc5010/common/motors/SystemIdentification.java
+++ b/src/main/java/org/frc5010/common/motors/SystemIdentification.java
@@ -83,6 +83,27 @@ public class SystemIdentification {
   }
 
   public static SysIdRoutine angleSysIdRoutine(
+      SmartMotorController motor, String motorName, SubsystemBase subsystemBase) {
+
+    return new SysIdRoutine(
+        new Config(Volts.of(1).div(Seconds.of(1)), Volts.of(1), Seconds.of(10)),
+        new SysIdRoutine.Mechanism(
+            (Voltage voltage) ->
+                motor.setDutyCycle(voltage.in(Volts) / RobotController.getBatteryVoltage()),
+            log -> {
+              motor.updateTelemetry();
+              motor.simIterate();
+              log.motor(motorName)
+                  .voltage(
+                      m_appliedVoltage.mut_replace(
+                          motor.getDutyCycle() * RobotController.getBatteryVoltage(), Volts))
+                  .angularPosition(m_distance.mut_replace(motor.getMechanismPosition()))
+                  .angularVelocity(m_velocity.mut_replace(motor.getMechanismVelocity()));
+            },
+            subsystemBase));
+  }
+
+  public static SysIdRoutine angleSysIdRoutine(
       GenericMotorController motor,
       GenericEncoder encoder,
       String motorName,


### PR DESCRIPTION
Rename example pivot device to turret and enhance pivot JSON with movementPlane, max velocity/acceleration, hard limits, starting angle, gearStages, and updated radius/mass/soft limits. Add sysid methods (sysIdArm, sysIdPivot, sysIdTurret) to ExampleIO, implement them in ExampleIOReal (including a new Pivot field and sysid helper calls) and forward them in ExampleSubsystem; map a controller button to run launcher.sysIdPivot in ExampleCommands. Extend Yams*ConfigurationJson classes to include a gearStages string and pass it into YamsConfigCommon, which now accepts gearStages and prefers GearBox.fromStages when provided (falling back to previous gearing array). Add a new SystemIdentification.angleSysIdRoutine overload for SmartMotorController to support angle-based sysid routines.