### PR TITLE
Use Controller accessors for joystick axes

### DIFF
--- a/src/main/java/org/frc5010/common/drive/swerve/GenericSwerveDrivetrain.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/GenericSwerveDrivetrain.java
@@ -36,7 +36,6 @@ import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.util.Color;
@@ -726,9 +725,9 @@ public class GenericSwerveDrivetrain extends GenericDrivetrain {
   }
 
   public Command createDefaultCommand(Controller driverXbox) {
-    DoubleSupplier leftX = () -> driverXbox.getAxisValue(XboxController.Axis.kLeftX.value);
-    DoubleSupplier leftY = () -> driverXbox.getAxisValue(XboxController.Axis.kLeftY.value);
-    DoubleSupplier rightX = () -> driverXbox.getAxisValue(XboxController.Axis.kRightX.value);
+    DoubleSupplier leftX = () -> driverXbox.getLeftXAxis();
+    DoubleSupplier leftY = () -> driverXbox.getLeftYAxis();
+    DoubleSupplier rightX = () -> driverXbox.getRightXAxis();
     BooleanSupplier isFieldOriented = () -> isFieldOrientedDrive.getValue();
 
     /**
@@ -749,9 +748,9 @@ public class GenericSwerveDrivetrain extends GenericDrivetrain {
   }
 
   public Command createDefaultTestCommand(Controller driverXbox) {
-    DoubleSupplier leftX = () -> driverXbox.getAxisValue(XboxController.Axis.kLeftX.value);
-    DoubleSupplier leftY = () -> driverXbox.getAxisValue(XboxController.Axis.kLeftY.value);
-    DoubleSupplier rightX = () -> driverXbox.getAxisValue(XboxController.Axis.kRightX.value);
+    DoubleSupplier leftX = () -> driverXbox.getLeftXAxis();
+    DoubleSupplier leftY = () -> driverXbox.getLeftYAxis();
+    DoubleSupplier rightX = () -> driverXbox.getRightXAxis();
     BooleanSupplier isFieldOriented = () -> isFieldOrientedDrive.getValue();
 
     driverXbox.createAButton().whileTrue(sysIdDriveMotorCommand());


### PR DESCRIPTION
Replace XboxController-specific getAxisValue calls with generic Controller accessor methods (getLeftXAxis, getLeftYAxis, getRightXAxis) in createDefaultCommand and createDefaultTestCommand. Also remove the now-unused XboxController import. This decouples the swerve drivetrain from XboxController constants and uses the project's Controller API.