### PR TITLE
Init and centralize alliance display update

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -43,6 +43,7 @@ public class RobotContainer implements WpiHelperInterface {
 
   // Just sets up defalt commands (setUpDeftCom)
   public void setupDefaults() {
+    robot.determineAlliance();
     robot.setupDefaultCommands();
   }
 

--- a/src/main/java/org/frc5010/common/arch/GenericRobot.java
+++ b/src/main/java/org/frc5010/common/arch/GenericRobot.java
@@ -135,7 +135,7 @@ public abstract class GenericRobot extends GenericMechanism implements GenericDe
         .schedule(
             Commands.run(
                     () -> {
-                      allianceDisplay.setValue(determineAlliance());
+                      determineAlliance();
                       LEDStrip.changeSegmentPattern(
                           ConfigConstants.ALL_LEDS, LEDStrip.getSolidPattern(allianceWpiColor));
                     })
@@ -289,6 +289,7 @@ public abstract class GenericRobot extends GenericMechanism implements GenericDe
   public String determineAlliance() {
     Optional<Alliance> color = DriverStation.getAlliance();
     alliance = color.orElse(Alliance.Blue);
+    allianceDisplay.setValue(alliance.name());
     allianceColor5010 =
         color.map(it -> it == Alliance.Red ? Color.RED : Color.BLUE).orElse(Color.ORANGE);
     allianceWpiColor =


### PR DESCRIPTION
Call determineAlliance() during RobotContainer.setupDefaults to initialize alliance state before default commands run, and move allianceDisplay.setValue(...) into GenericRobot.determineAlliance(). Also update the scheduled task to call determineAlliance() (rather than relying on its return value). These changes ensure the alliance display is initialized and kept in sync consistently.