### PR TITLE
Add SparkFlex support and NeoVortex motor

### DIFF
--- a/src/main/java/org/frc5010/common/config/json/devices/DeviceConfigReader.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/DeviceConfigReader.java
@@ -32,6 +32,7 @@ public class DeviceConfigReader {
     GenericMotorController motor;
     switch (controller) {
       case "spark":
+      case "sparkflex":
         motor = MotorFactory.Spark(id, Motor.valueOf(type));
         break;
       case "talonfx":
@@ -102,6 +103,7 @@ public class DeviceConfigReader {
             yamsShooterConfigurationJson.configure(system));
         break;
       default:
+        System.out.println("Unknown device key: " + key);
         break;
     }
   }
@@ -139,6 +141,9 @@ public class DeviceConfigReader {
         break;
       case "neo550":
         motorSim = DCMotor.getNeo550(numberOfMotors);
+        break;
+      case "neovortex":
+        motorSim = DCMotor.getNeoVortex(numberOfMotors);
         break;
       case "krakenx60":
         motorSim = DCMotor.getKrakenX60(numberOfMotors);

--- a/src/main/java/org/frc5010/common/motors/MotorFactory.java
+++ b/src/main/java/org/frc5010/common/motors/MotorFactory.java
@@ -55,17 +55,33 @@ public class MotorFactory {
 
   public static GenericMotorController Spark(int canId, Motor config) {
     switch (config) {
+      case KrakenX44:
       case KrakenX60:
-        throw new IllegalArgumentException("Sparks can not use KrakenX60 config");
+      case NeoVortex:
+        throw new IllegalArgumentException("Sparks can not use " + config + " config");
       default:
     }
-    return new GenericRevBrushlessMotor(canId, config);
+    return new GenericRevBrushlessMotor(canId, config, true);
+  }
+
+  public static GenericMotorController SparkFlex(int canId, Motor config) {
+    switch (config) {
+      case KrakenX44:
+      case KrakenX60:
+      case Neo550:
+      case Neo:
+        throw new IllegalArgumentException("Sparks can not use " + config + " config");
+      default:
+    }
+    return new GenericRevBrushlessMotor(canId, config, false);
   }
 
   public static GenericMotorController Thrifty(int canId, Motor config) {
     switch (config) {
+      case KrakenX44:
       case KrakenX60:
-        throw new IllegalArgumentException("Thrifty Novas can not use KrakenX60 config");
+      case NeoVortex:
+        throw new IllegalArgumentException("Thrifty can not use " + config + " config");
       default:
     }
     return new GenericThriftyNovaMotor(canId, config);

--- a/src/main/java/org/frc5010/common/motors/hardware/GenericRevBrushlessMotor.java
+++ b/src/main/java/org/frc5010/common/motors/hardware/GenericRevBrushlessMotor.java
@@ -85,12 +85,16 @@ public class GenericRevBrushlessMotor implements GenericMotorController {
    * @param currentLimit the current limit
    */
   public GenericRevBrushlessMotor(int port, Motor config, Current currentLimit) {
-    this(port, config);
+    this(port, config, true);
     setCurrentLimit(currentLimit);
   }
 
-  public GenericRevBrushlessMotor(int port, Motor config) {
-    motor = new SparkMax(port, MotorType.kBrushless);
+  public GenericRevBrushlessMotor(int port, Motor config, boolean maxOrFlex) {
+    if (maxOrFlex) {
+      motor = new SparkMax(port, MotorType.kBrushless);
+    } else {
+      motor = new SparkFlex(port, MotorType.kBrushless);
+    }
     this.config = config;
     factoryDefaults();
     clearStickyFaults();


### PR DESCRIPTION
Add support for SparkFlex controllers and NeoVortex motors: register "sparkflex" in DeviceConfigReader and add NeoVortex to the motor sim mapping. Introduce MotorFactory.SparkFlex to enforce different compatible Motor configs from Spark, and update Spark/Thrifty validation to handle NeoVortex. Refactor GenericRevBrushlessMotor to accept a flag selecting SparkMax vs SparkFlex hardware and update constructors accordingly. Also add a debug log for unknown device keys.