### PR TITLE
Use SparkFlex factory for sparkflex

### DIFF
--- a/src/main/java/org/frc5010/common/config/json/devices/DeviceConfigReader.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/DeviceConfigReader.java
@@ -32,8 +32,10 @@ public class DeviceConfigReader {
     GenericMotorController motor;
     switch (controller) {
       case "spark":
-      case "sparkflex":
         motor = MotorFactory.Spark(id, Motor.valueOf(type));
+        break;
+      case "sparkflex":
+        motor = MotorFactory.SparkFlex(id, Motor.valueOf(type));
         break;
       case "talonfx":
         motor = MotorFactory.TalonFX(id, Motor.valueOf(type));


### PR DESCRIPTION
Previously the 'sparkflex' label fell through to the 'spark' case and created a Spark controller. Add a dedicated 'sparkflex' switch case that constructs the controller with MotorFactory.SparkFlex(id, Motor.valueOf(type)) and include an explicit break to prevent fall-through. This ensures SparkFlex devices are instantiated with the correct factory.