### PR TITLE
Add SparkFlex simulation support

### DIFF
--- a/src/main/java/org/frc5010/common/motors/hardware/GenericRevBrushlessMotor.java
+++ b/src/main/java/org/frc5010/common/motors/hardware/GenericRevBrushlessMotor.java
@@ -10,6 +10,7 @@ import static edu.wpi.first.units.Units.Seconds;
 import com.revrobotics.PersistMode;
 import com.revrobotics.REVLibError;
 import com.revrobotics.ResetMode;
+import com.revrobotics.sim.SparkFlexSim;
 import com.revrobotics.sim.SparkMaxSim;
 import com.revrobotics.spark.FeedbackSensor;
 import com.revrobotics.spark.SparkBase;
@@ -52,6 +53,8 @@ public class GenericRevBrushlessMotor implements GenericMotorController {
   protected DCMotor motorSim;
   /** The maximum angular velocity */
   protected AngularVelocity maxRPM;
+  /** MaxOrFlex */
+  protected boolean maxOrFlex;
 
   /** The configuration of the motor */
   protected Motor config;
@@ -70,6 +73,7 @@ public class GenericRevBrushlessMotor implements GenericMotorController {
   private RevSparkController controller;
 
   public GenericRevBrushlessMotor(int port, boolean maxOrFlex) {
+    this.maxOrFlex = maxOrFlex;
     if (maxOrFlex) {
       motor = new SparkMax(port, MotorType.kBrushless);
     } else {
@@ -84,12 +88,13 @@ public class GenericRevBrushlessMotor implements GenericMotorController {
    * @param config the configuration
    * @param currentLimit the current limit
    */
-  public GenericRevBrushlessMotor(int port, Motor config, Current currentLimit) {
-    this(port, config, true);
+  public GenericRevBrushlessMotor(int port, Motor config, Current currentLimit, boolean maxOrFlex) {
+    this(port, config, maxOrFlex);
     setCurrentLimit(currentLimit);
   }
 
   public GenericRevBrushlessMotor(int port, Motor config, boolean maxOrFlex) {
+    this.maxOrFlex = maxOrFlex;
     if (maxOrFlex) {
       motor = new SparkMax(port, MotorType.kBrushless);
     } else {
@@ -118,7 +123,7 @@ public class GenericRevBrushlessMotor implements GenericMotorController {
   @Override
   public GenericMotorController duplicate(int port) {
     GenericMotorController duplicate =
-        new GenericRevBrushlessMotor(port, config, Amps.of(currentLimit));
+        new GenericRevBrushlessMotor(port, config, Amps.of(currentLimit), maxOrFlex);
     return duplicate;
   }
 
@@ -470,7 +475,11 @@ public class GenericRevBrushlessMotor implements GenericMotorController {
   @Override
   public void setMotorSimulationType(DCMotor motorSimulationType) {
     motorSim = motorSimulationType;
-    encoder.setSimulation(new SparkMaxSim(((SparkMax) motor), motorSim));
+    if (maxOrFlex) {
+      encoder.setSimulation(new SparkMaxSim(((SparkMax) motor), motorSim));
+    } else {
+      encoder.setSimulation(new SparkFlexSim(((SparkFlex) motor), motorSim));
+    }
   }
 
   /**

--- a/src/main/java/org/frc5010/common/sensors/encoder/RevEncoder.java
+++ b/src/main/java/org/frc5010/common/sensors/encoder/RevEncoder.java
@@ -5,7 +5,7 @@
 package org.frc5010.common.sensors.encoder;
 
 import com.revrobotics.RelativeEncoder;
-import com.revrobotics.sim.SparkMaxSim;
+import com.revrobotics.spark.SparkSim;
 import com.revrobotics.spark.config.EncoderConfig;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
@@ -14,7 +14,7 @@ import java.util.Optional;
 public class RevEncoder implements GenericEncoder {
   protected RelativeEncoder encoder;
   /** The simulated instance of the motor */
-  protected SparkMaxSim sparkMaxSim;
+  protected SparkSim sparkMaxSim;
 
   protected EncoderConfig config;
   protected double positionConversion = 1.0;
@@ -25,7 +25,7 @@ public class RevEncoder implements GenericEncoder {
     config = new EncoderConfig();
   }
 
-  public void setSimulation(SparkMaxSim sparkMaxSim) {
+  public void setSimulation(SparkSim sparkMaxSim) {
     this.sparkMaxSim = sparkMaxSim;
   }
 


### PR DESCRIPTION
Introduce support for REV SparkFlex simulation alongside SparkMax by adding a maxOrFlex flag and selecting SparkMaxSim or SparkFlexSim accordingly. Propagate the flag through constructors (including the currentLimit overload), update duplicate() to preserve the flag, and import com.revrobotics.sim.SparkFlexSim. Generalize RevEncoder to use the common com.revrobotics.spark.SparkSim type (rename field and setSimulation signature) so it can accept either simulator implementation.