### PR TITLE
Update ArmFeedforward constructor args

### DIFF
--- a/src/main/java/org/frc5010/common/config/json/devices/YamsPivotConfigurationJson.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/YamsPivotConfigurationJson.java
@@ -54,11 +54,13 @@ public class YamsPivotConfigurationJson implements DeviceConfiguration {
             .withFeedforward(
                 new ArmFeedforward(
                     motorSystemId.feedForward.s,
+                    0,
                     motorSystemId.feedForward.v,
                     motorSystemId.feedForward.a))
             .withFeedforward(
                 new ArmFeedforward(
                     simSystemId.feedForward.s,
+                    0,
                     simSystemId.feedForward.v,
                     simSystemId.feedForward.a))
             .withControlMode(ControlMode.valueOf(motorSystemId.controlMode));


### PR DESCRIPTION
Adapt to the updated ArmFeedforward constructor by inserting a 0 placeholder for the new parameter in both motor and sim feedforward initializations in YamsPivotConfigurationJson. This preserves prior behavior while matching the new signature.