### PR TITLE
Stale Odometry Signal Fix

### DIFF
--- a/src/main/java/org/frc5010/common/drive/swerve/akit/GyroIOPigeon2.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/akit/GyroIOPigeon2.java
@@ -37,10 +37,7 @@ public class GyroIOPigeon2 implements GyroIO {
     yawVelocity.setUpdateFrequency(50.0);
     pigeon.optimizeBusUtilization();
     yawTimestampQueue = TalonFXOdometryThread.getInstance().makeTimestampQueue();
-    var yawClone = yaw.clone(); // Status signals are not thread-safe
-    yawPositionQueue =
-        TalonFXOdometryThread.getInstance()
-            .registerSignal(() -> yawClone.refresh().getValueAsDouble());
+    yawPositionQueue = TalonFXOdometryThread.getInstance().registerSignal(yaw.clone());
   }
 
   @Override


### PR DESCRIPTION
Changed Pigeon2 Yaw Signal registration from a generic lambda into a PhoenixSignal, to ensure it gets put into the Phoenix update loop, rather than the generic AKit one, (hopefully) fixing stale odometry StatusSignals.