### PR TITLE
Refactor pose/drive, add Orchestra support

### DIFF
--- a/src/main/java/org/frc5010/common/arch/GenericRobot.java
+++ b/src/main/java/org/frc5010/common/arch/GenericRobot.java
@@ -170,7 +170,8 @@ public abstract class GenericRobot extends GenericMechanism implements GenericDe
   @Override
   protected void initRealOrSim() {
     if (RobotBase.isReal()) {
-      WpiDataLogging.start(true);
+      // WpiDataLogging.start(true);
+      // TODO: Resolve this, maybe do not double log
     } else {
       WpiDataLogging.start(false);
       // NetworkTableInstance instance = NetworkTableInstance.getDefault();
@@ -262,6 +263,10 @@ public abstract class GenericRobot extends GenericMechanism implements GenericDe
   public Command getAutonomousCommand() {
     everEnabled = true;
     return generateAutoCommand(selectableCommand.get().asProxy());
+  }
+
+  public static boolean hasEverEnabled() {
+    return everEnabled;
   }
 
   /** Executes periodic behavior when the robot is disabled. */

--- a/src/main/java/org/frc5010/common/arch/GenericSubsystem.java
+++ b/src/main/java/org/frc5010/common/arch/GenericSubsystem.java
@@ -4,6 +4,7 @@
 
 package org.frc5010.common.arch;
 
+import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
@@ -124,16 +125,14 @@ public class GenericSubsystem extends SubsystemBase
   @Override
   public void periodic() {
     DashBoard.notifyListeners();
-    devices.values().stream()
-        .forEach(
-            it -> {
-              if (it instanceof GenericFunctionalMotor) {
-                ((GenericFunctionalMotor) it).periodicUpdate();
-              }
-              if (it instanceof SmartMechanism) {
-                ((SmartMechanism) it).updateTelemetry();
-              }
-            });
+    for (Object it : devices.values()) {
+      if (it instanceof GenericFunctionalMotor) {
+        ((GenericFunctionalMotor) it).periodicUpdate();
+      }
+      if (it instanceof SmartMechanism) {
+        ((SmartMechanism) it).updateTelemetry();
+      }
+    }
   }
 
   /**
@@ -142,16 +141,14 @@ public class GenericSubsystem extends SubsystemBase
    */
   @Override
   public void simulationPeriodic() {
-    devices.values().stream()
-        .forEach(
-            it -> {
-              if (it instanceof GenericFunctionalMotor) {
-                ((GenericFunctionalMotor) it).simulationUpdate();
-              }
-              if (it instanceof SmartMechanism) {
-                ((SmartMechanism) it).simIterate();
-              }
-            });
+    for (Object it : devices.values()) {
+      if (it instanceof GenericFunctionalMotor) {
+        ((GenericFunctionalMotor) it).simulationUpdate();
+      }
+      if (it instanceof SmartMechanism) {
+        ((SmartMechanism) it).simIterate();
+      }
+    }
   }
 
   /**
@@ -171,5 +168,10 @@ public class GenericSubsystem extends SubsystemBase
    */
   public void setDisplay(boolean display) {
     if (display) DashBoard.makeDisplayed();
+  }
+
+  public static Object setHeight(Distance of) {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'setHeight'");
   }
 }

--- a/src/main/java/org/frc5010/common/commands/AkitDriveCommands.java
+++ b/src/main/java/org/frc5010/common/commands/AkitDriveCommands.java
@@ -25,6 +25,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
@@ -57,7 +58,7 @@ public class AkitDriveCommands {
   private static final double FF_RAMP_RATE = 0.1; // Volts/Sec
   private static final double WHEEL_RADIUS_MAX_VELOCITY = 0.25; // Rad/Sec
   private static final double WHEEL_RADIUS_RAMP_RATE = 0.05; // Rad/Sec^2
-  private static final double PID_TUNING_VOLTAGE = 2.0; // Volts - voltage to apply during tuning
+  private static final double PID_TUNING_VOLTAGE = 30.0; // Volts - voltage to apply during tuning
   private static final double PID_TUNING_DELAY = 1.0; // Secs - initial delay before measurements
 
   private AkitDriveCommands() {}
@@ -259,6 +260,24 @@ public class AkitDriveCommands {
   }
 
   /**
+   * Measures the velocity feedforward constants for the drive motors using TorqueCurrentFOC.
+   *
+   * <p>This command should only be used in torque current control mode.
+   *
+   * @param subsystem the swerve drivetrain subsystem to characterize
+   * @param characterizer consumer that accepts current values to apply to drive motors
+   * @param velocitySupplier supplier that returns the current velocity for measurement
+   * @return a command that performs feedforward characterization and logs results
+   */
+  public static Command torqueCurrentFeedforwardCharacterization(
+      GenericSubsystem subsystem,
+      Consumer<Current> characterizer,
+      Supplier<Double> velocitySupplier) {
+    return org.frc5010.common.motors.SystemIdentification.torqueCurrentFeedforwardCharacterization(
+        subsystem, characterizer, velocitySupplier);
+  }
+
+  /**
    * Measures the robot's wheel radius by spinning in a circle.
    *
    * @param swerveDrive the swerve drivetrain subsystem to characterize
@@ -379,8 +398,7 @@ public class AkitDriveCommands {
                             // Transition to new setpoint
                             Commands.runOnce(
                                 () -> {
-                                  ChassisSpeeds speeds =
-                                      new ChassisSpeeds(targetVelocity, 0.0, 0.0);
+                                  ChassisSpeeds speeds = new ChassisSpeeds(0, 0.0, targetVelocity);
                                   drive.runVelocity(speeds);
                                 }),
 
@@ -391,7 +409,7 @@ public class AkitDriveCommands {
                             Commands.run(
                                     () -> {
                                       ChassisSpeeds speeds =
-                                          new ChassisSpeeds(targetVelocity, 0.0, 0.0);
+                                          new ChassisSpeeds(0, 0.0, targetVelocity);
                                       drive.runVelocity(speeds);
 
                                       // Calculate velocity error: difference between setpoint
@@ -399,8 +417,7 @@ public class AkitDriveCommands {
                                       double avgVelocity = 0.0;
                                       for (int i = 0; i < 4; i++) {
                                         avgVelocity +=
-                                            drive.getModulesInfo()[i]
-                                                .driveVelocityMetersPerSecond();
+                                            drive.getModulesInfo()[i].driveVelocityMetersPerSecond;
                                       }
                                       avgVelocity /= 4.0;
                                       double error = Math.abs(targetVelocity - avgVelocity);
@@ -497,7 +514,7 @@ public class AkitDriveCommands {
                                   double avgAngleError = 0.0;
                                   for (int i = 0; i < 4; i++) {
                                     double currentAngle =
-                                        drive.getModulesInfo()[i].steerAbsoluteDegrees();
+                                        drive.getModulesInfo()[i].steerAbsoluteDegrees;
                                     double error = Math.abs(targetDegrees - currentAngle);
                                     // Handle angle wrapping (shortest path)
                                     if (error > 180.0) {

--- a/src/main/java/org/frc5010/common/config/RobotParser.java
+++ b/src/main/java/org/frc5010/common/config/RobotParser.java
@@ -19,6 +19,7 @@ import org.frc5010.common.config.json.RobotJson;
 import org.frc5010.common.config.json.VisionPropertiesJson;
 import org.frc5010.common.config.json.YAGSLDrivetrainJson;
 import org.frc5010.common.config.json.devices.LEDStripParser;
+import org.frc5010.common.config.json.devices.OrchestraParser;
 
 /**
  * Parses JSON configuration files to initialize and build a robot's subsystems.
@@ -107,6 +108,9 @@ public class RobotParser {
 
     // Parse LED strips
     LEDStripParser.parse(robotDirectory);
+
+    // Parse the orchestra configuration (if it exists)
+    OrchestraParser.parse(robotDirectory);
 
     // Read in the drivetrain
     switch (robotJson.driveType) {

--- a/src/main/java/org/frc5010/common/config/json/AKitSwerveDrivetrainJson.java
+++ b/src/main/java/org/frc5010/common/config/json/AKitSwerveDrivetrainJson.java
@@ -76,27 +76,26 @@ public class AKitSwerveDrivetrainJson implements DrivetrainPropertiesJson {
                 1),
             getModuleTranslations(config));
 
-    SwerveDriveFunctions.mapleSimConfig =
-        DriveTrainSimulationConfig.Default()
-            .withBumperSize(config.getBumperFrameWidth(), config.getBumperFrameLength())
-            .withRobotMass(config.getRobotMass())
-            .withCustomModuleTranslations(getModuleTranslations(config))
-            .withGyro(COTS.ofPigeon2())
-            .withSwerveModule(
-                new SwerveModuleSimulationConfig(
-                    DeviceConfigReader.getSimulatedMotor(
-                        constants.modules.get("frontLeft").driveMotorSetup.motorType, 1),
-                    DeviceConfigReader.getSimulatedMotor(
-                        constants.modules.get("frontLeft").steerMotorSetup.motorType, 1),
-                    config.getDriveGearRatio(),
-                    config.getSteerGearRatio(),
-                    Volts.of(config.FrontLeft.DriveFrictionVoltage),
-                    Volts.of(config.FrontLeft.SteerFrictionVoltage),
-                    Meters.of(config.FrontLeft.WheelRadius),
-                    KilogramSquareMeters.of(config.FrontLeft.SteerInertia),
-                    constants.wheelCOF));
-
     if (RobotBase.isSimulation()) {
+      SwerveDriveFunctions.mapleSimConfig =
+          DriveTrainSimulationConfig.Default()
+              .withBumperSize(config.getBumperFrameWidth(), config.getBumperFrameLength())
+              .withRobotMass(config.getRobotMass())
+              .withCustomModuleTranslations(getModuleTranslations(config))
+              .withGyro(COTS.ofPigeon2())
+              .withSwerveModule(
+                  new SwerveModuleSimulationConfig(
+                      DeviceConfigReader.getSimulatedMotor(
+                          constants.modules.get("frontLeft").driveMotorSetup.motorType, 1),
+                      DeviceConfigReader.getSimulatedMotor(
+                          constants.modules.get("frontLeft").steerMotorSetup.motorType, 1),
+                      config.getDriveGearRatio(),
+                      config.getSteerGearRatio(),
+                      Volts.of(config.FrontLeft.DriveFrictionVoltage),
+                      Volts.of(config.FrontLeft.SteerFrictionVoltage),
+                      Meters.of(config.FrontLeft.WheelRadius),
+                      KilogramSquareMeters.of(config.FrontLeft.SteerInertia),
+                      constants.wheelCOF));
       SwerveDriveFunctions.driveSimulation =
           new SwerveDriveSimulation(
               SwerveDriveFunctions.mapleSimConfig, new Pose2d(3, 3, new Rotation2d()));

--- a/src/main/java/org/frc5010/common/config/json/devices/OrchestraConfigJson.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/OrchestraConfigJson.java
@@ -1,0 +1,21 @@
+package org.frc5010.common.config.json.devices;
+
+import org.frc5010.common.utils.OrchestraManager;
+
+public class OrchestraConfigJson {
+  public int[] rioIds = {};
+
+  // TalonFX CAN IDs on the CANivore bus
+  public int[] canivoreIds = {};
+
+  public static class MusicEntry {
+    public String name = "";
+    public String path = "";
+  }
+
+  public MusicEntry[] music = {};
+
+  public void configure() {
+    OrchestraManager.init(this);
+  }
+}

--- a/src/main/java/org/frc5010/common/config/json/devices/OrchestraParser.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/OrchestraParser.java
@@ -1,0 +1,25 @@
+package org.frc5010.common.config.json.devices;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.wpi.first.wpilibj.Filesystem;
+import java.io.File;
+import java.io.IOException;
+
+public class OrchestraParser {
+  public static void parse(String robotDirectory) {
+    try {
+      File directory = new File(Filesystem.getDeployDirectory(), robotDirectory + "/subsystems");
+      DeviceConfigReader.checkDirectory(directory);
+      File deviceFile = new File(directory, "orchestra.json");
+      if (!deviceFile.exists()) {
+        return;
+      }
+      OrchestraConfigJson orchestraConfig =
+          new ObjectMapper().readValue(deviceFile, OrchestraConfigJson.class);
+      orchestraConfig.configure();
+    } catch (IOException e) {
+      System.out.println("Error reading device configuration: " + e.getMessage());
+      return;
+    }
+  }
+}

--- a/src/main/java/org/frc5010/common/config/json/devices/YamsArmConfigurationJson.java
+++ b/src/main/java/org/frc5010/common/config/json/devices/YamsArmConfigurationJson.java
@@ -37,6 +37,7 @@ public class YamsArmConfigurationJson implements DeviceConfiguration {
   public UnitValueJson mass = new UnitValueJson(0, MassUnit.POUNDS.toString());
   public UnitValueJson voltageCompensation = new UnitValueJson(12, VoltageUnit.VOLTS.toString());
   public UnitValueJson horizontalZero = new UnitValueJson(0, AngleUnit.DEGREES.toString());
+  public boolean useTorqueCurrentFOC = true;
 
   /**
    * Configure the given GenericSubsystem with an arm using the given json configuration.

--- a/src/main/java/org/frc5010/common/drive/pose/DrivePoseEstimator.java
+++ b/src/main/java/org/frc5010/common/drive/pose/DrivePoseEstimator.java
@@ -24,19 +24,95 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.frc5010.common.arch.GenericSubsystem;
 import org.frc5010.common.commands.calibration.PoseProviderAutoOffset;
 import org.frc5010.common.drive.GenericDrivetrain;
 import org.frc5010.common.drive.pose.PoseProvider.PoseObservation;
+import org.frc5010.common.drive.pose.PoseProvider.PoseObservationType;
 import org.frc5010.common.drive.pose.PoseProvider.ProviderType;
 import org.frc5010.common.subsystems.LEDStripSegment;
 import org.frc5010.common.telemetry.DisplayBoolean;
 import org.frc5010.common.vision.AprilTags;
 import org.frc5010.common.vision.VisionConstants;
+import org.littletonrobotics.junction.AutoLog;
+import org.littletonrobotics.junction.Logger;
 
 /** A class to handle estimating the pose of the robot */
 public class DrivePoseEstimator extends GenericSubsystem {
+
+  public enum VisionRejectionReason {
+    NONE,
+    NO_TAGS,
+    HIGH_AMBIGUITY,
+    BAD_Z,
+    OUT_OF_BOUNDS
+  }
+
+  public static record VisionObservationDiagnostic(
+      int cameraIndex,
+      ProviderType providerType,
+      PoseObservationType observationType,
+      double timestamp,
+      Pose3d pose,
+      double ambiguity,
+      int tagCount,
+      double averageTagDistance,
+      boolean accepted,
+      VisionRejectionReason rejectionReason,
+      boolean acceptorCandidate,
+      double xStdDev,
+      double yStdDev,
+      double thetaStdDev) {
+    public static final VisionObservationDiagnostic EMPTY =
+        new VisionObservationDiagnostic(
+            -1,
+            ProviderType.NONE,
+            PoseObservationType.PHOTONVISION,
+            0.0,
+            new Pose3d(),
+            0.0,
+            0,
+            0.0,
+            false,
+            VisionRejectionReason.NONE,
+            false,
+            Double.NaN,
+            Double.NaN,
+            Double.NaN);
+  }
+
+  @AutoLog
+  public static class DrivePoseEstimatorInputs {
+    public Pose2d pose2d = new Pose2d();
+    public Pose3d pose3d = new Pose3d();
+    public int providerCount = 0;
+    public int activeProviderCount = 0;
+    public int observationsReceived = 0;
+    public int observationsAccepted = 0;
+    public int observationsRejected = 0;
+    public int noTagRejectCount = 0;
+    public int ambiguityRejectCount = 0;
+    public int zRejectCount = 0;
+    public int outOfBoundsRejectCount = 0;
+    public int acceptorCandidateCount = 0;
+    public boolean visionApplied = false;
+    public boolean acceptorUpdating = false;
+    public boolean poseAcceptable = false;
+    public boolean visionUpdateDisabled = false;
+    public boolean acceptorUpdatesEnabled = false;
+    public State estimatorState = State.DISABLED_FIELD;
+    public double confidenceResetThreshold = 0.0;
+    public double maxAmbiguity = 0.0;
+    public double maxZError = 0.0;
+    public double linearStdDevBaseline = 0.0;
+    public double angularStdDevBaseline = 0.0;
+    public double linearStdDevMegatag2Factor = 0.0;
+    public double angularStdDevMegatag2Factor = 0.0;
+    public double[] cameraStdDevFactors = new double[0];
+    public VisionObservationDiagnostic[] visionObservationDiagnostics =
+        new VisionObservationDiagnostic[0];
+  }
+
   /** The pose tracker */
   protected GenericPose poseTracker;
   /** The field2d object for displaying the pose */
@@ -47,6 +123,17 @@ public class DrivePoseEstimator extends GenericSubsystem {
   private boolean disableVisionUpdateCommand = false;
   /** List of PoseProviders */
   private List<PoseProvider> poseProviders = new ArrayList<>();
+  /** Reusable filtered list to avoid per-cycle stream/collect allocation */
+  private final List<PoseProvider> activePoseProviders = new ArrayList<>();
+  /** Cached current pose in 3D — updated once per periodic() to avoid per-call allocation */
+  private Pose3d cachedPose3d = new Pose3d();
+  /** Pre-allocated array for Shuffleboard pose3d widget — filled in-place each cycle */
+  private final double[] pose3dArray = new double[7];
+  /** Reused list for estimator-side observation diagnostics. */
+  private final List<VisionObservationDiagnostic> visionObservationDiagnostics = new ArrayList<>();
+  /** Pre-allocated array for estimator-side observation diagnostics. */
+  private VisionObservationDiagnostic[] visionObservationDiagnosticsArray =
+      new VisionObservationDiagnostic[0];
 
   private DisplayBoolean aprilTagVisible = DashBoard.makeDisplayBoolean("AprilTagVisible");
   private boolean updatingPoseAcceptor = false;
@@ -54,6 +141,8 @@ public class DrivePoseEstimator extends GenericSubsystem {
   private static double CONFIDENCE_RESET_THRESHOLD = 0.025;
   private boolean activateAcceptorUpdates = true;
   private boolean poseAcceptable = false;
+
+  private DrivePoseEstimatorInputsAutoLogged inputs = new DrivePoseEstimatorInputsAutoLogged();
 
   public static enum State {
     DISABLED_FIELD(ProviderType.FIELD_BASED),
@@ -179,7 +268,7 @@ public class DrivePoseEstimator extends GenericSubsystem {
    */
   public Pose2d getCurrentPose() {
     // return poseProviders.get(0).getRobotPose().get().toPose2d();
-    return poseTracker.getCurrentPose();
+    return inputs.pose2d;
   }
 
   /**
@@ -188,7 +277,7 @@ public class DrivePoseEstimator extends GenericSubsystem {
    * @return the current pose with z = 0
    */
   public Pose3d getCurrentPose3d() {
-    return new Pose3d(poseTracker.getCurrentPose());
+    return cachedPose3d;
   }
 
   /**
@@ -197,29 +286,63 @@ public class DrivePoseEstimator extends GenericSubsystem {
    * @return the current pose
    */
   public double[] getCurrentPose3dArray() {
-    Pose3d pose = getCurrentPose3d();
-    Quaternion rotation = pose.getRotation().getQuaternion();
-    return new double[] {
-      pose.getX(),
-      pose.getY(),
-      pose.getZ(),
-      rotation.getW(),
-      rotation.getX(),
-      rotation.getY(),
-      rotation.getZ()
-    };
+    Quaternion rotation = cachedPose3d.getRotation().getQuaternion();
+    pose3dArray[0] = cachedPose3d.getX();
+    pose3dArray[1] = cachedPose3d.getY();
+    pose3dArray[2] = cachedPose3d.getZ();
+    pose3dArray[3] = rotation.getW();
+    pose3dArray[4] = rotation.getX();
+    pose3dArray[5] = rotation.getY();
+    pose3dArray[6] = rotation.getZ();
+    return pose3dArray;
+  }
+
+  private void updateInputs(DrivePoseEstimatorInputsAutoLogged input) {
+    input.pose3d = getCurrentPose3d();
+    input.pose2d = poseTracker.getCurrentPose();
+    input.providerCount = poseProviders.size();
+    input.activeProviderCount = activePoseProviders.size();
+    input.visionUpdateDisabled = disableVisionUpdateCommand;
+    input.acceptorUpdatesEnabled = activateAcceptorUpdates;
+    input.estimatorState = state;
+    input.confidenceResetThreshold = CONFIDENCE_RESET_THRESHOLD;
+    input.maxAmbiguity = VisionConstants.maxAmbiguity;
+    input.maxZError = VisionConstants.maxZError;
+    input.linearStdDevBaseline = VisionConstants.linearStdDevBaseline;
+    input.angularStdDevBaseline = VisionConstants.angularStdDevBaseline;
+    input.linearStdDevMegatag2Factor = VisionConstants.linearStdDevMegatag2Factor;
+    input.angularStdDevMegatag2Factor = VisionConstants.angularStdDevMegatag2Factor;
+    if (input.cameraStdDevFactors.length != VisionConstants.cameraStdDevFactors.length) {
+      input.cameraStdDevFactors = new double[VisionConstants.cameraStdDevFactors.length];
+    }
+    System.arraycopy(
+        VisionConstants.cameraStdDevFactors,
+        0,
+        input.cameraStdDevFactors,
+        0,
+        VisionConstants.cameraStdDevFactors.length);
   }
 
   @Override
   public void periodic() {
-    poseProviders.forEach(it -> it.update());
+    for (int i = 0; i < poseProviders.size(); i++) {
+      poseProviders.get(i).update();
+    }
+    // Refresh cached pose BEFORE updatePoseObservationFromProviders() so that getCurrentPose3d()
+    // returns the current cycle's odometry pose for the acceptor distance check and pose reset.
+    cachedPose3d = new Pose3d(poseTracker.getCurrentPose());
     updatePoseObservationFromProviders();
+    // Re-cache after vision fusion so field2d and consumers see the vision-fused pose.
+    cachedPose3d = new Pose3d(poseTracker.getCurrentPose());
     field2d.setRobotPose(getCurrentPose());
+    updateInputs(inputs);
+    Logger.processInputs("PoseEstimator", inputs);
   }
 
   private void resetProviderPoses(Pose2d pose) {
-    for (PoseProvider provider : poseProviders) {
-      provider.resetPose(new Pose3d(pose));
+    Pose3d pose3d = new Pose3d(pose);
+    for (int i = 0; i < poseProviders.size(); i++) {
+      poseProviders.get(i).resetPose(pose3d);
     }
   }
 
@@ -237,45 +360,37 @@ public class DrivePoseEstimator extends GenericSubsystem {
     poseTracker.updateLocalMeasurements();
     boolean visionUpdated = false;
     boolean accepterUpdating = false;
+    int observationsReceived = 0;
+    int observationsAccepted = 0;
+    int observationsRejected = 0;
+    int noTagRejectCount = 0;
+    int ambiguityRejectCount = 0;
+    int zRejectCount = 0;
+    int outOfBoundsRejectCount = 0;
+    int acceptorCandidateCount = 0;
     poseAcceptable = false;
+    activePoseProviders.clear();
+    visionObservationDiagnostics.clear();
     if (!disableVisionUpdateCommand) {
-      for (PoseProvider provider :
-          poseProviders.stream()
-              .filter(
-                  it ->
-                      it.isConnected()
-                          && (state.type == ProviderType.ALL || it.getType() == state.type))
-              .collect(Collectors.toList())) {
-        List<PoseObservation> observations = provider.getObservations();
-        for (PoseObservation observation : observations) {
-          boolean rejectPose =
-              (provider.getType() != ProviderType.ENVIRONMENT_BASED)
-                      && observation.tagCount() == 0 // Must have at least one tag
-                  || (observation.tagCount() == 1
-                      && observation.ambiguity()
-                          > VisionConstants.maxAmbiguity) // Cannot be high ambiguity
-                  || Math.abs(observation.pose().getZ())
-                      > VisionConstants.maxZError // Must have realistic Z coordinate
-
-                  // Must be within the field boundaries
-                  || observation.pose().getX() < 0.0
-                  || observation.pose().getX() > AprilTags.aprilTagFieldLayout.getFieldLength()
-                  || observation.pose().getY() < 0.0
-                  || observation.pose().getY() > AprilTags.aprilTagFieldLayout.getFieldWidth();
-
+      // Build the filtered provider list without stream/collect allocation
+      for (int i = 0; i < poseProviders.size(); i++) {
+        PoseProvider p = poseProviders.get(i);
+        if (p.isConnected() && (state.type == ProviderType.ALL || p.getType() == state.type)) {
+          activePoseProviders.add(p);
+        }
+      }
+      for (int pi = 0; pi < activePoseProviders.size(); pi++) {
+        PoseProvider provider = activePoseProviders.get(pi);
+        PoseObservation[] observations = provider.getObservationsArray();
+        // Cache current pose once per provider to avoid repeated calls inside the observation loop
+        Pose3d cachedCurrentPose3d = getCurrentPose3d();
+        for (int oi = 0; oi < observations.length; oi++) {
+          PoseObservation observation = observations[oi];
+          observationsReceived++;
+          VisionRejectionReason rejectionReason = getVisionRejectionReason(provider, observation);
+          boolean rejectPose = rejectionReason != VisionRejectionReason.NONE;
           Pose3d robotPose = observation.pose();
-          if (!rejectPose) {
-            visionUpdated |= true;
-            poseTracker
-                .getVisionConsumer()
-                .accept(
-                    robotPose.toPose2d(),
-                    observation.timestamp(),
-                    provider.getStdDeviations(observation));
-          }
-
-          // Decides if pose would be good to update
-          poseAcceptable |=
+          boolean acceptorCandidate =
               activateAcceptorUpdates
                   && provider.getType() == ProviderType.FIELD_BASED
                   && (state == State.ENABLED_FIELD || state == State.ALL)
@@ -284,15 +399,73 @@ public class DrivePoseEstimator extends GenericSubsystem {
                       || (!DriverStation.isDisabled()
                           && robotPose
                                   .getTranslation()
-                                  .getDistance(getCurrentPose3d().getTranslation())
+                                  .getDistance(cachedCurrentPose3d.getTranslation())
                               < 0.1));
+
+          Matrix<N3, N1> stdDevs = null;
+          double xStdDev = Double.NaN;
+          double yStdDev = Double.NaN;
+          double thetaStdDev = Double.NaN;
+          if (!rejectPose) {
+            stdDevs = provider.getStdDeviations(observation);
+            xStdDev = stdDevs.get(0, 0);
+            yStdDev = stdDevs.get(1, 0);
+            thetaStdDev = stdDevs.get(2, 0);
+            observationsAccepted++;
+            visionUpdated |= true;
+            poseTracker
+                .getVisionConsumer()
+                .accept(robotPose.toPose2d(), observation.timestamp(), stdDevs);
+          } else {
+            observationsRejected++;
+            switch (rejectionReason) {
+              case NO_TAGS:
+                noTagRejectCount++;
+                break;
+              case HIGH_AMBIGUITY:
+                ambiguityRejectCount++;
+                break;
+              case BAD_Z:
+                zRejectCount++;
+                break;
+              case OUT_OF_BOUNDS:
+                outOfBoundsRejectCount++;
+                break;
+              case NONE:
+                break;
+            }
+          }
+
+          // Decides if pose would be good to update
+          if (acceptorCandidate) {
+            acceptorCandidateCount++;
+          }
+          poseAcceptable |= acceptorCandidate;
+
+          visionObservationDiagnostics.add(
+              new VisionObservationDiagnostic(
+                  provider.getCameraIndex(),
+                  provider.getType(),
+                  observation.type(),
+                  observation.timestamp(),
+                  robotPose,
+                  observation.ambiguity(),
+                  observation.tagCount(),
+                  observation.averageTagDistance(),
+                  !rejectPose,
+                  rejectionReason,
+                  acceptorCandidate,
+                  xStdDev,
+                  yStdDev,
+                  thetaStdDev));
         }
       }
     }
 
     // Accept poses after estimation integration
     if (activateAcceptorUpdates && (poseAcceptable || state == State.DISABLED_FIELD)) {
-      for (PoseProvider provider2 : poseProviders) {
+      for (int i = 0; i < poseProviders.size(); i++) {
+        PoseProvider provider2 = poseProviders.get(i);
         if (provider2.getType() == ProviderType.ENVIRONMENT_BASED) {
           provider2.resetPose(getCurrentPose3d());
           accepterUpdating = true;
@@ -302,6 +475,45 @@ public class DrivePoseEstimator extends GenericSubsystem {
 
     aprilTagVisible.setValue(visionUpdated);
     updatingPoseAcceptor = accepterUpdating;
+    inputs.observationsReceived = observationsReceived;
+    inputs.observationsAccepted = observationsAccepted;
+    inputs.observationsRejected = observationsRejected;
+    inputs.noTagRejectCount = noTagRejectCount;
+    inputs.ambiguityRejectCount = ambiguityRejectCount;
+    inputs.zRejectCount = zRejectCount;
+    inputs.outOfBoundsRejectCount = outOfBoundsRejectCount;
+    inputs.acceptorCandidateCount = acceptorCandidateCount;
+    inputs.visionApplied = visionUpdated;
+    inputs.acceptorUpdating = accepterUpdating;
+    inputs.poseAcceptable = poseAcceptable;
+    if (visionObservationDiagnosticsArray.length != visionObservationDiagnostics.size()) {
+      visionObservationDiagnosticsArray =
+          new VisionObservationDiagnostic[visionObservationDiagnostics.size()];
+    }
+    for (int i = 0; i < visionObservationDiagnostics.size(); i++) {
+      visionObservationDiagnosticsArray[i] = visionObservationDiagnostics.get(i);
+    }
+    inputs.visionObservationDiagnostics = visionObservationDiagnosticsArray;
+  }
+
+  private VisionRejectionReason getVisionRejectionReason(
+      PoseProvider provider, PoseObservation observation) {
+    if (provider.getType() != ProviderType.ENVIRONMENT_BASED && observation.tagCount() == 0) {
+      return VisionRejectionReason.NO_TAGS;
+    }
+    if (observation.tagCount() == 1 && observation.ambiguity() > VisionConstants.maxAmbiguity) {
+      return VisionRejectionReason.HIGH_AMBIGUITY;
+    }
+    if (Math.abs(observation.pose().getZ()) > VisionConstants.maxZError) {
+      return VisionRejectionReason.BAD_Z;
+    }
+    if (observation.pose().getX() < 0.0
+        || observation.pose().getX() > AprilTags.aprilTagFieldLayout.getFieldLength()
+        || observation.pose().getY() < 0.0
+        || observation.pose().getY() > AprilTags.aprilTagFieldLayout.getFieldWidth()) {
+      return VisionRejectionReason.OUT_OF_BOUNDS;
+    }
+    return VisionRejectionReason.NONE;
   }
 
   public void setState(State type) {

--- a/src/main/java/org/frc5010/common/drive/pose/PoseProvider.java
+++ b/src/main/java/org/frc5010/common/drive/pose/PoseProvider.java
@@ -8,10 +8,9 @@ import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.wpilibj.Alert;
-import edu.wpi.first.wpilibj.Alert.AlertType;
 import java.util.Arrays;
 import java.util.List;
 import org.frc5010.common.vision.VisionConstants;
@@ -20,9 +19,19 @@ import org.littletonrobotics.junction.Logger;
 
 public interface PoseProvider {
 
-  public VisionIOInputsAutoLogged input = new VisionIOInputsAutoLogged();
-  public Alert disconnectedAlert = new Alert("PoseProvider", AlertType.kWarning);
-  public int cameraIndex = 0;
+  /**
+   * Returns this provider's own {@link VisionIOInputsAutoLogged} instance.
+   *
+   * <p>Each implementing class must declare and return its own instance. The old pattern of a
+   * single {@code public VisionIOInputsAutoLogged input} field on the interface was implicitly
+   * {@code static final} in Java — meaning all cameras shared one object and each camera's {@code
+   * updateCameraInfo()} overwrote the previous camera's observations.
+   *
+   * @return the per-instance inputs object
+   */
+  public VisionIOInputsAutoLogged getInput();
+
+  public int getCameraIndex();
 
   public enum ProviderType {
     ALL,
@@ -39,6 +48,12 @@ public interface PoseProvider {
     ENVIRONMENT_BASED,
   }
 
+  public enum PhotonPoseMethod {
+    NONE,
+    MULTITAG,
+    TRIG
+  }
+
   @AutoLog
   public static class VisionIOInputs {
     public boolean connected = false;
@@ -47,11 +62,84 @@ public interface PoseProvider {
     public Pose3d latestTargetPose = new Pose3d();
     public double captureTime;
     public PoseObservation[] poseObservations = new PoseObservation[0];
-    public int[] tagIds = new int[0];
+    //    public int[] tagIds = new int[0];
+    /** Total summed distance to all visible tags (meters) */
+    public double totalTagDistance = 0.0;
+    /** Pose ambiguity of the best visible target */
+    public double poseAmbiguity = 0.0;
+    /** Latest estimated robot pose from this camera */
+    public Pose3d estimatedRobotPose = new Pose3d();
+    /** Count of unread PhotonVision frames returned this cycle */
+    public int unreadResultCount = 0;
+    /** Count of PhotonVision frames processed after capping */
+    public int processedResultCount = 0;
+    /** Count of PhotonVision frames dropped by the per-cycle cap */
+    public int droppedResultCount = 0;
+    /** Per-frame PhotonVision diagnostics for offline pose/filter tuning */
+    public PhotonFrameObservation[] photonFrameObservations = new PhotonFrameObservation[0];
   }
 
   /** Represents the angle to a simple target, not used for pose estimation. */
   public static record TargetRotation(Rotation3d rotation) {}
+
+  /** Logged raw pose-relevant data for a single tracked PhotonVision target. */
+  public static record PhotonTargetObservation(
+      int fiducialId,
+      double yaw,
+      double pitch,
+      double area,
+      double skew,
+      double ambiguity,
+      Transform3d bestCameraToTarget,
+      Transform3d altCameraToTarget) {
+    public static final PhotonTargetObservation EMPTY =
+        new PhotonTargetObservation(
+            -1, 0.0, 0.0, 0.0, 0.0, 0.0, new Transform3d(), new Transform3d());
+  }
+
+  /** Logged data for one pose-solve method from a PhotonVision frame. */
+  public static record PhotonPoseEstimate(
+      boolean present,
+      Pose3d pose,
+      double ambiguity,
+      int tagCount,
+      double averageTagDistance,
+      int[] tagIds) {
+    public static final PhotonPoseEstimate EMPTY =
+        new PhotonPoseEstimate(false, new Pose3d(), 0.0, 0, 0.0, new int[0]);
+  }
+
+  /** Logged raw and solved data for a single PhotonVision frame. */
+  public static record PhotonFrameObservation(
+      double timestamp,
+      double latencyMillis,
+      long sequenceId,
+      long publishTimestampMicros,
+      int targetCount,
+      double totalTagDistance,
+      int[] multitagFiducialIds,
+      Transform3d rawMultitagBestTransform,
+      double rawMultitagAmbiguity,
+      PhotonPoseMethod selectedMethod,
+      PhotonPoseEstimate multiTagEstimate,
+      PhotonPoseEstimate trigEstimate,
+      PhotonTargetObservation[] targets) {
+    public static final PhotonFrameObservation EMPTY =
+        new PhotonFrameObservation(
+            0.0,
+            0.0,
+            0L,
+            0L,
+            0,
+            0.0,
+            new int[0],
+            new Transform3d(),
+            0.0,
+            PhotonPoseMethod.NONE,
+            PhotonPoseEstimate.EMPTY,
+            PhotonPoseEstimate.EMPTY,
+            new PhotonTargetObservation[0]);
+  }
 
   /** Represents a robot pose sample used for pose estimation. */
   public static record PoseObservation(
@@ -69,7 +157,16 @@ public interface PoseProvider {
    * @return The current observations of the robot.
    */
   public default List<PoseObservation> getObservations() {
-    return Arrays.asList(input.poseObservations);
+    return Arrays.asList(getInput().poseObservations);
+  }
+
+  /**
+   * Returns the raw observations array without wrapping — zero allocation per call.
+   *
+   * @return The current observations of the robot as a raw array.
+   */
+  public default PoseObservation[] getObservationsArray() {
+    return getInput().poseObservations;
   }
 
   /*
@@ -79,11 +176,11 @@ public interface PoseProvider {
    * @return Whether the pose provider is currently active.
    */
   public default boolean isConnected() {
-    return input.connected;
+    return getInput().connected;
   }
 
   public default double getCaptureTime() {
-    return input.captureTime;
+    return getInput().captureTime;
   }
 
   public void update();
@@ -93,7 +190,7 @@ public interface PoseProvider {
   public ProviderType getType();
 
   public default void logInput(String tableName) {
-    Logger.processInputs(VisionConstants.SBTabVisionDisplay + "/Camera " + tableName, input);
+    Logger.processInputs(VisionConstants.SBTabVisionDisplay + "/Camera " + tableName, getInput());
   }
 
   public default Matrix<N3, N1> getStdDeviations(PoseObservation observation) {
@@ -105,9 +202,9 @@ public interface PoseProvider {
       linearStdDev *= VisionConstants.linearStdDevMegatag2Factor;
       angularStdDev *= VisionConstants.angularStdDevMegatag2Factor;
     }
-    if (cameraIndex < VisionConstants.cameraStdDevFactors.length) {
-      linearStdDev *= VisionConstants.cameraStdDevFactors[cameraIndex];
-      angularStdDev *= VisionConstants.cameraStdDevFactors[cameraIndex];
+    if (getCameraIndex() < VisionConstants.cameraStdDevFactors.length) {
+      linearStdDev *= VisionConstants.cameraStdDevFactors[getCameraIndex()];
+      angularStdDev *= VisionConstants.cameraStdDevFactors[getCameraIndex()];
     }
 
     return VecBuilder.fill(linearStdDev, linearStdDev, angularStdDev);

--- a/src/main/java/org/frc5010/common/drive/swerve/AkitSwerveConfig.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/AkitSwerveConfig.java
@@ -156,14 +156,17 @@ public class AkitSwerveConfig extends SwerveDriveConfig {
                       .withKS(constants.driveMotorControl.feedForward.s)
                       .withKV(constants.driveMotorControl.feedForward.v)
                       .withKA(constants.driveMotorControl.feedForward.a))
-              .withSteerMotorClosedLoopOutput(ClosedLoopOutputType.Voltage)
-              .withDriveMotorClosedLoopOutput(ClosedLoopOutputType.Voltage)
+              .withSteerMotorClosedLoopOutput(ClosedLoopOutputType.TorqueCurrentFOC)
+              .withDriveMotorClosedLoopOutput(ClosedLoopOutputType.TorqueCurrentFOC)
               .withSlipCurrent(UnitsParser.parseAmps(constants.slipCurrent))
               .withSpeedAt12Volts(UnitsParser.parseVelocity(constants.maxDriveSpeed))
               .withDriveMotorType(DriveMotorArrangement.TalonFX_Integrated)
               .withSteerMotorType(SteerMotorArrangement.TalonFX_Integrated)
               .withFeedbackSource(SteerFeedbackType.FusedCANcoder)
-              .withDriveMotorInitialConfigs(new TalonFXConfiguration())
+              .withDriveMotorInitialConfigs(
+                  new TalonFXConfiguration()
+                      .withCurrentLimits(
+                          new CurrentLimitsConfigs().withSupplyCurrentLimit(Amps.of(30))))
               .withSteerMotorInitialConfigs(
                   new TalonFXConfiguration()
                       .withCurrentLimits(

--- a/src/main/java/org/frc5010/common/drive/swerve/GenericSwerveDrivetrain.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/GenericSwerveDrivetrain.java
@@ -120,18 +120,25 @@ public class GenericSwerveDrivetrain extends GenericDrivetrain {
         ppRobotConfigSupplier.get(), // The robot configuration
         () -> {
           // Boolean supplier that controls when the path will be mirrored for the red
-          // alliance
-          // This will flip the path being followed to the red side of the field.
+          // alliance.
           // THE ORIGIN WILL REMAIN ON THE BLUE SIDE
-          var alliance = GenericRobot.getAlliance();
-          SmartDashboard.putString("YAGSL Alliance", alliance.toString());
-          return alliance == DriverStation.Alliance.Red;
+          return GenericRobot.getAlliance() == DriverStation.Alliance.Red;
         },
         this // Reference to this subsystem to set requirements
         );
 
-    // Preload PathPlanner Path finding
+    // Preload PathPlanner Path finding.
     // IF USING CUSTOM PATHFINDER ADD BEFORE THIS LINE
+    warmupPathfinding();
+  }
+
+  /**
+   * Schedules the PathPlanner pathfinding warmup command. Safe to call during robotInit() because
+   * the command is decorated with ignoringDisable(true), which lets it run while the robot is
+   * disabled. Calling this early prevents the ~180 ms overrun that occurs when warmup finishes
+   * mid-match the first time a PathfindingCommand is instantiated.
+   */
+  public void warmupPathfinding() {
     CommandScheduler.getInstance().schedule(PathfindingCommand.warmupCommand());
   }
 
@@ -144,18 +151,18 @@ public class GenericSwerveDrivetrain extends GenericDrivetrain {
   public void updateGlassWidget() {
     GenericSwerveModuleInfo[] modules = swerveDrive.getModulesInfo();
     for (int moduleKey = 0; moduleKey < modules.length; moduleKey++) {
-      double turningDeg = modules[moduleKey].steerRelativeDegrees();
-      double absEncDeg = modules[moduleKey].steerAbsoluteDegrees();
+      double turningDeg = modules[moduleKey].steerRelativeDegrees;
+      double absEncDeg = modules[moduleKey].steerAbsoluteDegrees;
       // This method will be called once per scheduler run
       absEncDials.get(moduleKey).setAngle(absEncDeg + 90);
       motorDials.get(moduleKey).setAngle(turningDeg + 90);
       motorDials
           .get(moduleKey)
-          .setLength(0.1 * modules[moduleKey].steerVelocityDegreesPerSecond() + 0.02);
+          .setLength(0.1 * modules[moduleKey].steerVelocityDegreesPerSecond + 0.02);
       expectDials
           .get(moduleKey)
-          .setLength(0.1 * modules[moduleKey].driveVelocityMetersPerSecond() + 0.02);
-      expectDials.get(moduleKey).setAngle(modules[moduleKey].expectedSteerDegrees() + 90);
+          .setLength(0.1 * modules[moduleKey].driveVelocityMetersPerSecond + 0.02);
+      expectDials.get(moduleKey).setAngle(modules[moduleKey].expectedSteerDegrees + 90);
     }
   }
 
@@ -572,9 +579,7 @@ public class GenericSwerveDrivetrain extends GenericDrivetrain {
     if (Double.isNaN(xInput)
         || Double.isNaN(yInput)
         || Double.isNaN(turnSpdFunction.getAsDouble())) {
-      SmartDashboard.putBoolean("Controller Overide", true);
-    } else {
-      SmartDashboard.putBoolean("Controller Overide", false);
+      // Input is NaN — fall through to previous-value substitution below
     }
 
     xInput = Double.isNaN(xInput) ? previousLeftXInput : xInput;

--- a/src/main/java/org/frc5010/common/drive/swerve/GenericSwerveModuleInfo.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/GenericSwerveModuleInfo.java
@@ -7,32 +7,41 @@ package org.frc5010.common.drive.swerve;
 import org.frc5010.common.drive.swerve.akit.Module;
 import swervelib.SwerveModule;
 
-/** Add your docs here. */
-public record GenericSwerveModuleInfo(
-    double steerAbsoluteDegrees,
-    double steerRelativeDegrees,
-    double driveRelativePositionMeters,
-    double driveVelocityMetersPerSecond,
-    double steerVelocityDegreesPerSecond,
-    double expectedSteerDegrees) {
+/**
+ * Mutable container for swerve module telemetry — reused each cycle to avoid per-call allocation.
+ * Use {@link #update(Module)} / {@link #update(SwerveModule)} to refresh values in-place.
+ */
+public class GenericSwerveModuleInfo {
+  public double steerAbsoluteDegrees;
+  public double steerRelativeDegrees;
+  public double driveRelativePositionMeters;
+  public double driveVelocityMetersPerSecond;
+  public double steerVelocityDegreesPerSecond;
+  public double expectedSteerDegrees;
 
-  public GenericSwerveModuleInfo(SwerveModule module) {
-    this(
-        module.getAbsolutePosition(),
-        module.getRelativePosition(),
-        module.getDriveMotor().getPosition(),
-        module.getDriveMotor().getVelocity(),
-        module.getAngleMotor().getVelocity(),
-        module.getState().angle.getDegrees());
+  public GenericSwerveModuleInfo() {}
+
+  /** Update all fields from a YAGSL {@link SwerveModule} — zero allocation after first call. */
+  public void update(SwerveModule module) {
+    steerAbsoluteDegrees = module.getAbsolutePosition();
+    steerRelativeDegrees = module.getRelativePosition();
+    driveRelativePositionMeters = module.getDriveMotor().getPosition();
+    driveVelocityMetersPerSecond = module.getDriveMotor().getVelocity();
+    steerVelocityDegreesPerSecond = module.getAngleMotor().getVelocity();
+    expectedSteerDegrees = module.getState().angle.getDegrees();
   }
 
-  public GenericSwerveModuleInfo(Module module) {
-    this(
-        module.getAngle().getDegrees(),
-        module.getAngle().getDegrees(),
-        module.getPosition().distanceMeters,
-        module.getVelocityMetersPerSec(),
-        0.0,
-        module.getAngle().getDegrees());
+  /**
+   * Update all fields from an AKit {@link Module} — zero allocation after first call. Reads {@code
+   * inputs} values directly to avoid the allocating {@link Module#getPosition()} call.
+   */
+  public void update(Module module) {
+    double angleDeg = module.getAngle().getDegrees();
+    steerAbsoluteDegrees = angleDeg;
+    steerRelativeDegrees = angleDeg;
+    driveRelativePositionMeters = module.getPositionMeters();
+    driveVelocityMetersPerSecond = module.getVelocityMetersPerSec();
+    steerVelocityDegreesPerSecond = 0.0;
+    expectedSteerDegrees = angleDeg;
   }
 }

--- a/src/main/java/org/frc5010/common/drive/swerve/YAGSLSwerveDrivetrain.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/YAGSLSwerveDrivetrain.java
@@ -605,9 +605,14 @@ public class YAGSLSwerveDrivetrain extends SwerveDriveFunctions {
   @Override
   public GenericSwerveModuleInfo[] getModulesInfo() {
     SwerveModule[] modules = swerveDrive.getModules();
-    if (null == moduleInfos) moduleInfos = new GenericSwerveModuleInfo[modules.length];
+    if (null == moduleInfos) {
+      moduleInfos = new GenericSwerveModuleInfo[modules.length];
+      for (int i = 0; i < modules.length; i++) {
+        moduleInfos[i] = new GenericSwerveModuleInfo();
+      }
+    }
     for (int i = 0; i < modules.length; i++) {
-      moduleInfos[i] = new GenericSwerveModuleInfo(modules[i]);
+      moduleInfos[i].update(modules[i]);
     }
     return moduleInfos;
   }

--- a/src/main/java/org/frc5010/common/drive/swerve/akit/AkitSwerveDrive.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/akit/AkitSwerveDrive.java
@@ -7,6 +7,7 @@
 
 package org.frc5010.common.drive.swerve.akit;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Second;
 import static edu.wpi.first.units.Units.Volts;
@@ -31,6 +32,7 @@ import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Force;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.Alert;
@@ -80,6 +82,27 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
       };
   private SwerveDrivePoseEstimator poseEstimator;
   private final Consumer<Pose2d> resetSimulationPoseCallBack;
+
+  // Pre-allocated odometry buffers — sized for max odometry samples per 20ms loop.
+  // At 250 Hz odometry the theoretical max is ~5 samples; 16 provides ample headroom.
+  private static final int MAX_ODOMETRY_SAMPLES = 16;
+  /** Empty array sentinel for disabled-mode logging — never mutated */
+  private static final SwerveModuleState[] EMPTY_MODULE_STATES = new SwerveModuleState[] {};
+
+  private final SwerveModulePosition[][] odometryModulePositions =
+      new SwerveModulePosition[MAX_ODOMETRY_SAMPLES][4];
+  private final SwerveModulePosition[][] odometryModuleDeltas =
+      new SwerveModulePosition[MAX_ODOMETRY_SAMPLES][4];
+
+  {
+    // Pre-populate every slot so no null checks are needed in the hot loop
+    for (int s = 0; s < MAX_ODOMETRY_SAMPLES; s++) {
+      for (int m = 0; m < 4; m++) {
+        odometryModulePositions[s][m] = new SwerveModulePosition();
+        odometryModuleDeltas[s][m] = new SwerveModulePosition();
+      }
+    }
+  }
 
   public AkitSwerveDrive(
       AkitSwerveConfig config,
@@ -145,8 +168,8 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
 
     // Log empty setpoint states when disabled
     if (DriverStation.isDisabled()) {
-      Logger.recordOutput("SwerveStates/Setpoints", new SwerveModuleState[] {});
-      Logger.recordOutput("SwerveStates/SetpointsOptimized", new SwerveModuleState[] {});
+      Logger.recordOutput("SwerveStates/Setpoints", EMPTY_MODULE_STATES);
+      Logger.recordOutput("SwerveStates/SetpointsOptimized", EMPTY_MODULE_STATES);
     }
 
     getChassisSpeeds();
@@ -154,19 +177,20 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
     // Update odometry
     double[] sampleTimestamps =
         modules[0].getOdometryTimestamps(); // All signals are sampled together
-    int sampleCount = sampleTimestamps.length;
+    int sampleCount = Math.min(sampleTimestamps.length, MAX_ODOMETRY_SAMPLES);
     for (int i = 0; i < sampleCount; i++) {
-      // Read wheel positions and deltas from each module
-      SwerveModulePosition[] modulePositions = new SwerveModulePosition[4];
-      SwerveModulePosition[] moduleDeltas = new SwerveModulePosition[4];
+      // Reuse pre-allocated position / delta arrays for this sample
+      SwerveModulePosition[] modulePositions = odometryModulePositions[i];
+      SwerveModulePosition[] moduleDeltas = odometryModuleDeltas[i];
       for (int moduleIndex = 0; moduleIndex < 4; moduleIndex++) {
-        modulePositions[moduleIndex] = modules[moduleIndex].getOdometryPositions()[i];
-        moduleDeltas[moduleIndex] =
-            new SwerveModulePosition(
-                modulePositions[moduleIndex].distanceMeters
-                    - lastModulePositions[moduleIndex].distanceMeters,
-                modulePositions[moduleIndex].angle);
-        lastModulePositions[moduleIndex] = modulePositions[moduleIndex];
+        SwerveModulePosition freshPos = modules[moduleIndex].getOdometryPositions()[i];
+        modulePositions[moduleIndex].distanceMeters = freshPos.distanceMeters;
+        modulePositions[moduleIndex].angle = freshPos.angle;
+        moduleDeltas[moduleIndex].distanceMeters =
+            freshPos.distanceMeters - lastModulePositions[moduleIndex].distanceMeters;
+        moduleDeltas[moduleIndex].angle = freshPos.angle;
+        lastModulePositions[moduleIndex].distanceMeters = freshPos.distanceMeters;
+        lastModulePositions[moduleIndex].angle = freshPos.angle;
       }
 
       // Update gyro angle
@@ -192,7 +216,7 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
    *
    * @param speeds Speeds in meters/sec
    */
-  public void runVelocity(ChassisSpeeds speeds) {
+  public void runVelocity(ChassisSpeeds speeds, Current[] torqueCurrents) {
     // Calculate module setpoints
     ChassisSpeeds discreteSpeeds = ChassisSpeeds.discretize(speeds, 0.02);
     SwerveModuleState[] setpointStates = kinematics.toSwerveModuleStates(discreteSpeeds);
@@ -204,11 +228,15 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
 
     // Send setpoints to modules
     for (int i = 0; i < 4; i++) {
-      modules[i].runSetpoint(setpointStates[i]);
+      modules[i].runSetpoint(setpointStates[i], torqueCurrents[i]);
     }
 
     // Log optimized setpoints (runSetpoint mutates each state)
     Logger.recordOutput("SwerveStates/SetpointsOptimized", setpointStates);
+  }
+
+  public void runVelocity(ChassisSpeeds speeds) {
+    runVelocity(speeds, new Current[] {Amps.zero(), Amps.zero(), Amps.zero(), Amps.zero()});
   }
 
   /** Runs the drive in a straight line with the specified drive output. */
@@ -369,6 +397,7 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
   }
 
   @Override
+  @AutoLogOutput(key = "SwerveChassisSpeeds/FieldMeasured")
   public ChassisSpeeds getFieldVelocity() {
     return ChassisSpeeds.fromRobotRelativeSpeeds(getChassisSpeeds(), getRotation());
   }
@@ -378,6 +407,7 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
    * Uses the same kinematics math as velocity, but with per-module acceleration instead of
    * velocity.
    */
+  @AutoLogOutput(key = "SwerveChassisAcceleration/Robot")
   public ChassisSpeeds getChassisAcceleration() {
     SwerveModuleState[] accelStates = new SwerveModuleState[4];
     for (int i = 0; i < 4; i++) {
@@ -389,13 +419,14 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
   /**
    * Returns the field-relative chassis acceleration derived from drive motor acceleration signals.
    */
+  @AutoLogOutput(key = "SwerveChassisAcceleration/Field")
   public ChassisSpeeds getFieldAcceleration() {
     return ChassisSpeeds.fromRobotRelativeSpeeds(getChassisAcceleration(), getRotation());
   }
 
   @Override
   public void drive(ChassisSpeeds velocity, DriveFeedforwards feedforwards) {
-    runVelocity(velocity);
+    runVelocity(velocity, feedforwards.torqueCurrents());
   }
 
   @Override
@@ -482,9 +513,14 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
 
   @Override
   public GenericSwerveModuleInfo[] getModulesInfo() {
-    if (null == moduleInfos) moduleInfos = new GenericSwerveModuleInfo[modules.length];
+    if (null == moduleInfos) {
+      moduleInfos = new GenericSwerveModuleInfo[modules.length];
+      for (int i = 0; i < modules.length; i++) {
+        moduleInfos[i] = new GenericSwerveModuleInfo();
+      }
+    }
     for (int i = 0; i < modules.length; i++) {
-      moduleInfos[i] = new GenericSwerveModuleInfo(modules[i]);
+      moduleInfos[i].update(modules[i]);
     }
     return moduleInfos;
   }
@@ -533,6 +569,9 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
     selectableCommand.addOption(
         "PRO: Swerve Wheel Radius Characterization",
         AkitDriveCommands.wheelRadiusCharacterization(drivetrain, this));
+
+    selectableCommand.addOption(
+        "PRO: Swerve Drive PID Tuning", AkitDriveCommands.drivePIDTuning(drivetrain, this));
     selectableCommand.addOption(
         "PRO: Swerve Drive Feedforward Characterization",
         AkitDriveCommands.feedforwardCharacterization(
@@ -544,6 +583,20 @@ public class AkitSwerveDrive extends SwerveDriveFunctions {
         AkitDriveCommands.feedforwardCharacterization(
             drivetrain,
             (Voltage voltage) -> runSteerCharacterization(voltage.in(Volts)),
+            () -> getSteerFFCharacterizationVelocity()));
+
+    selectableCommand.addOption(
+        "PRO: Swerve Drive TorqueCurrent Characterization",
+        AkitDriveCommands.torqueCurrentFeedforwardCharacterization(
+            drivetrain,
+            (edu.wpi.first.units.measure.Current current) -> runCharacterization(current.in(Amps)),
+            () -> getDriveFFCharacterizationVelocity()));
+    selectableCommand.addOption(
+        "PRO: Swerve Steer TorqueCurrent Characterization",
+        AkitDriveCommands.torqueCurrentFeedforwardCharacterization(
+            drivetrain,
+            (edu.wpi.first.units.measure.Current current) ->
+                runSteerCharacterization(current.in(Amps)),
             () -> getSteerFFCharacterizationVelocity()));
 
     selectableCommand.addOption(

--- a/src/main/java/org/frc5010/common/drive/swerve/akit/Module.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/akit/Module.java
@@ -7,12 +7,15 @@
 
 package org.frc5010.common.drive.swerve.akit;
 
+import static edu.wpi.first.units.Units.Amps;
+
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.swerve.SwerveModuleConstants;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
 import frc.robot.Robot;
@@ -31,7 +34,8 @@ public class Module {
   private final Alert turnDisconnectedAlert;
   private final Alert turnEncoderDisconnectedAlert;
 
-  private SwerveModulePosition[] odometryPositions = new SwerveModulePosition[] {};
+  /** Grow-only array: never shrunk to minimise GC pressure from per-cycle allocation */
+  private SwerveModulePosition[] odometryPositions = new SwerveModulePosition[0];
 
   public Module(
       ModuleIO io,
@@ -63,11 +67,17 @@ public class Module {
         Math.min(
             inputs.odometryDrivePositionsRad.length,
             inputs.odometryTurnPositions.length); // All signals are sampled together
-    odometryPositions = new SwerveModulePosition[sampleCount];
+    // Grow the array only when needed; never shrink to avoid per-cycle GC pressure
+    if (odometryPositions.length != sampleCount) {
+      odometryPositions = new SwerveModulePosition[sampleCount];
+      for (int i = 0; i < sampleCount; i++) {
+        odometryPositions[i] = new SwerveModulePosition();
+      }
+    }
     for (int i = 0; i < sampleCount; i++) {
-      double positionMeters = inputs.odometryDrivePositionsRad[i] * constants.WheelRadius;
-      Rotation2d angle = inputs.odometryTurnPositions[i];
-      odometryPositions[i] = new SwerveModulePosition(positionMeters, angle);
+      odometryPositions[i].distanceMeters =
+          inputs.odometryDrivePositionsRad[i] * constants.WheelRadius;
+      odometryPositions[i].angle = inputs.odometryTurnPositions[i];
     }
 
     // Update alerts
@@ -77,14 +87,18 @@ public class Module {
   }
 
   /** Runs the module with the specified setpoint state. Mutates the state to optimize it. */
-  public void runSetpoint(SwerveModuleState state) {
+  public void runSetpoint(SwerveModuleState state, Current torqueCurrent) {
     // Optimize velocity setpoint
     state.optimize(getAngle());
     state.cosineScale(Robot.isSimulation() ? inputs.turnAbsolutePosition : inputs.turnPosition);
 
     // Apply setpoints
-    io.setDriveVelocity(state.speedMetersPerSecond / constants.WheelRadius);
+    io.setDriveVelocity(state.speedMetersPerSecond / constants.WheelRadius, torqueCurrent);
     io.setTurnPosition(state.angle);
+  }
+
+  public void runSetpoint(SwerveModuleState state) {
+    runSetpoint(state, Amps.zero());
   }
 
   /** Runs the module with the specified output while controlling to rotation angles. */

--- a/src/main/java/org/frc5010/common/drive/swerve/akit/ModuleIO.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/akit/ModuleIO.java
@@ -8,6 +8,7 @@
 package org.frc5010.common.drive.swerve.akit;
 
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.units.measure.Current;
 import org.littletonrobotics.junction.AutoLog;
 
 public interface ModuleIO {
@@ -44,6 +45,11 @@ public interface ModuleIO {
 
   /** Run the drive motor at the specified velocity. */
   public default void setDriveVelocity(double velocityRadPerSec) {}
+
+  /** Run the drive motor at the specified velocity and torque current. */
+  public default void setDriveVelocity(double velocityRadPerSec, Current torqueCurrent) {
+    setDriveVelocity(velocityRadPerSec);
+  }
 
   /** Run the turn motor to the specified rotation. */
   public default void setTurnPosition(Rotation2d rotation) {}

--- a/src/main/java/org/frc5010/common/drive/swerve/akit/ModuleIOTalonFX.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/akit/ModuleIOTalonFX.java
@@ -1,5 +1,6 @@
 package org.frc5010.common.drive.swerve.akit;
 
+import static edu.wpi.first.units.Units.Amps;
 import static org.frc5010.common.drive.swerve.akit.util.PhoenixUtil.tryUntilOk;
 
 import com.ctre.phoenix6.BaseStatusSignal;
@@ -57,6 +58,7 @@ public abstract class ModuleIOTalonFX implements ModuleIO {
   protected final StatusSignal<AngularAcceleration> driveAcceleration;
   protected final StatusSignal<Voltage> driveAppliedVolts;
   protected final StatusSignal<Current> driveCurrent;
+  protected final StatusSignal<Boolean> driveIsProLicensed;
 
   // Inputs from turn motor
   protected final StatusSignal<Angle> turnPosition;
@@ -141,6 +143,7 @@ public abstract class ModuleIOTalonFX implements ModuleIO {
     driveAcceleration = driveTalon.getAcceleration();
     driveAppliedVolts = driveTalon.getMotorVoltage();
     driveCurrent = driveTalon.getStatorCurrent();
+    driveIsProLicensed = driveTalon.getIsProLicensed();
 
     // Create turn status signals
     turnPosition = turnTalon.getPosition();
@@ -158,6 +161,8 @@ public abstract class ModuleIOTalonFX implements ModuleIO {
         driveAcceleration,
         driveAppliedVolts,
         driveCurrent,
+        driveIsProLicensed,
+        turnAbsolutePosition,
         turnVelocity,
         turnAppliedVolts,
         turnCurrent);
@@ -216,13 +221,20 @@ public abstract class ModuleIOTalonFX implements ModuleIO {
   }
 
   @Override
-  public void setDriveVelocity(double wheelVelocityRadPerSec) {
-    double velocityRotPerSec = Units.radiansToRotations(wheelVelocityRadPerSec);
+  public void setDriveVelocity(double wheelVelocityRadPerSec, Current current) {
+    double motorVelocityRotPerSec = Units.radiansToRotations(wheelVelocityRadPerSec);
     driveTalon.setControl(
         switch (constants.DriveMotorClosedLoopOutput) {
-          case Voltage -> velocityVoltageRequest.withVelocity(velocityRotPerSec);
-          case TorqueCurrentFOC -> velocityTorqueCurrentRequest.withVelocity(velocityRotPerSec);
+          case Voltage -> velocityVoltageRequest.withVelocity(motorVelocityRotPerSec);
+          case TorqueCurrentFOC -> velocityTorqueCurrentRequest
+              .withVelocity(motorVelocityRotPerSec)
+              .withFeedForward(current);
         });
+  }
+
+  @Override
+  public void setDriveVelocity(double velocityRadPerSec) {
+    setDriveVelocity(velocityRadPerSec, Amps.of(0.0));
   }
 
   @Override

--- a/src/main/java/org/frc5010/common/drive/swerve/akit/ModuleIOTalonFXReal.java
+++ b/src/main/java/org/frc5010/common/drive/swerve/akit/ModuleIOTalonFXReal.java
@@ -13,6 +13,8 @@
 
 package org.frc5010.common.drive.swerve.akit;
 
+import com.ctre.phoenix6.configs.CANcoderConfiguration;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.swerve.SwerveModuleConstants;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.util.Units;
@@ -31,7 +33,10 @@ public class ModuleIOTalonFXReal extends ModuleIOTalonFX {
   private final Queue<Double> drivePositionQueue;
   private final Queue<Double> turnPositionQueue;
 
-  public ModuleIOTalonFXReal(AkitSwerveConfig config, SwerveModuleConstants constants) {
+  public ModuleIOTalonFXReal(
+      AkitSwerveConfig config,
+      SwerveModuleConstants<TalonFXConfiguration, TalonFXConfiguration, CANcoderConfiguration>
+          constants) {
     super(config, constants);
 
     this.timestampQueue = TalonFXOdometryThread.getInstance().makeTimestampQueue();

--- a/src/main/java/org/frc5010/common/motors/SystemIdentification.java
+++ b/src/main/java/org/frc5010/common/motors/SystemIdentification.java
@@ -4,6 +4,7 @@
 
 package org.frc5010.common.motors;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.DegreesPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
@@ -11,6 +12,8 @@ import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
+import com.ctre.phoenix6.hardware.TalonFX;
+import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.MutAngle;
 import edu.wpi.first.units.measure.MutAngularVelocity;
 import edu.wpi.first.units.measure.MutVoltage;
@@ -38,6 +41,9 @@ import yams.motorcontrollers.SmartMotorController;
 public class SystemIdentification {
   /** Tracks the voltage being applied to a motor */
   private static final MutVoltage m_appliedVoltage = new MutVoltage(0, 0, Volts);
+
+  private static final edu.wpi.first.units.measure.MutCurrent m_appliedCurrent =
+      new edu.wpi.first.units.measure.MutCurrent(0, 0, Amps);
   /** Tracks the distance travelled of a position motor */
   private static final MutAngle m_distance = new MutAngle(0, 0, Rotations);
   /** Tracks the velocity of a positional motor */
@@ -131,6 +137,35 @@ public class SystemIdentification {
                   .angularPosition(m_anglePosition.mut_replace(encoder.getPosition(), Degrees))
                   .angularVelocity(
                       m_angVelocity.mut_replace(encoder.getVelocity(), DegreesPerSecond));
+            },
+            subsystemBase));
+  }
+
+  public static SysIdRoutine torqueCurrentSysIdRoutine(
+      SmartMotorController motor, String motorName, SubsystemBase subsystemBase) {
+
+    return new SysIdRoutine(
+        new Config(
+            Volts.of(5).div(Seconds.of(1)),
+            Volts.of(40),
+            Seconds.of(10)), // Note: Volts measure is interpreted as Amps
+        new SysIdRoutine.Mechanism(
+            (Voltage current) ->
+                ((TalonFX) motor.getMotorController())
+                    .setControl(new com.ctre.phoenix6.controls.TorqueCurrentFOC(current.in(Volts))),
+            log -> {
+              motor.updateTelemetry();
+              motor.simIterate();
+              if (motor.getMotorController()
+                  instanceof com.ctre.phoenix6.hardware.TalonFX talonFX) {
+                log.motor(motorName)
+                    .voltage(
+                        m_appliedVoltage.mut_replace(
+                            talonFX.getTorqueCurrent().getValueAsDouble(),
+                            Volts)) // Log as voltage so SysId tool accepts it, but value is Amps
+                    .angularPosition(m_distance.mut_replace(motor.getMechanismPosition()))
+                    .angularVelocity(m_velocity.mut_replace(motor.getMechanismVelocity()));
+              }
             },
             subsystemBase));
   }
@@ -229,6 +264,78 @@ public class SystemIdentification {
                   SmartDashboard.putNumber("Characterization/Feedforward/kS", kS);
                   SmartDashboard.putNumber("Characterization/Feedforward/kV", kV);
                   SmartDashboard.putNumber("Characterization/Feedforward/kA", kA);
+                }));
+  }
+
+  /**
+   * Measures the velocity feedforward constants for the motors using TorqueCurrentFOC.
+   *
+   * <p>This command should only be used in torque current control mode.
+   *
+   * @param subsystem the swerve drivetrain subsystem to characterize
+   * @param characterizer consumer that accepts current values to apply to motors
+   * @param velocitySupplier supplier that returns the current velocity for measurement
+   * @return a command that performs feedforward characterization and logs results
+   */
+  public static Command torqueCurrentFeedforwardCharacterization(
+      GenericSubsystem subsystem,
+      Consumer<Current> characterizer,
+      Supplier<Double> velocitySupplier) {
+    List<Double> velocitySamples = new LinkedList<>();
+    List<Double> currentSamples = new LinkedList<>();
+    List<Double> timeSamples = new LinkedList<>();
+    Timer timer = new Timer();
+
+    return Commands.sequence(
+        // Reset data
+        Commands.runOnce(
+            () -> {
+              velocitySamples.clear();
+              currentSamples.clear();
+              timeSamples.clear();
+            }),
+
+        // Allow modules to orient
+        Commands.run(
+                () -> {
+                  characterizer.accept(Amps.of(0.0));
+                },
+                subsystem)
+            .withTimeout(FF_START_DELAY),
+
+        // Start timer
+        Commands.runOnce(timer::restart),
+
+        // Accelerate and gather data
+        Commands.run(
+                () -> {
+                  double current =
+                      timer.get() * FF_RAMP_RATE * 5.0; // Ramp faster for Amps (e.g. 0.5 A/s)
+                  characterizer.accept(Amps.of(current));
+                  velocitySamples.add(velocitySupplier.get());
+                  currentSamples.add(current);
+                  timeSamples.add(timer.get());
+                },
+                subsystem)
+
+            // When cancelled, calculate and print results
+            .finallyDo(
+                () -> {
+                  double[] coefficients =
+                      computeFeedforwardCoefficients(velocitySamples, currentSamples, timeSamples);
+                  double kS = coefficients[0];
+                  double kV = coefficients[1];
+                  double kA = coefficients[2];
+
+                  NumberFormat formatter = new DecimalFormat("#0.00000");
+                  System.out.println(
+                      "********** TorqueCurrent FF Characterization Results **********");
+                  System.out.println("\tkS (Amps): " + formatter.format(kS));
+                  System.out.println("\tkV (Amps / (rad/s)): " + formatter.format(kV));
+                  System.out.println("\tkA (Amps / (rad/s^2)): " + formatter.format(kA));
+                  SmartDashboard.putNumber("Characterization/TorqueCurrentFeedforward/kS", kS);
+                  SmartDashboard.putNumber("Characterization/TorqueCurrentFeedforward/kV", kV);
+                  SmartDashboard.putNumber("Characterization/TorqueCurrentFeedforward/kA", kA);
                 }));
   }
 

--- a/src/main/java/org/frc5010/common/sensors/camera/GenericCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/GenericCamera.java
@@ -12,10 +12,13 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import java.util.ArrayList;
 import java.util.List;
 import org.frc5010.common.drive.pose.PoseProvider;
+import org.frc5010.common.drive.pose.VisionIOInputsAutoLogged;
 import org.frc5010.common.vision.VisionConstants;
 
 /** A generic camera interface */
 public abstract class GenericCamera implements PoseProvider {
+  /** Per-instance inputs — each camera has its own object so observations are not overwritten */
+  protected final VisionIOInputsAutoLogged input = new VisionIOInputsAutoLogged();
   /** The list of updaters that will be called every time the camera is updated */
   protected List<Runnable> updaters = new ArrayList<>();
   /** The robot-to-camera transform */
@@ -55,6 +58,18 @@ public abstract class GenericCamera implements PoseProvider {
     visionLayout.addDouble("Target Pitch", this::getTargetPitch);
     visionLayout.addDouble("Target Area", this::getTargetArea);
     visionLayout.addDouble("Latency", this::getCaptureTime);
+  }
+
+  /** {@inheritDoc} Returns this camera's own per-instance inputs object. */
+  @Override
+  public VisionIOInputsAutoLogged getInput() {
+    return input;
+  }
+
+  /** {@inheritDoc} Returns this camera's column index, used for std-dev scaling. */
+  @Override
+  public int getCameraIndex() {
+    return colIndex;
   }
 
   /**

--- a/src/main/java/org/frc5010/common/sensors/camera/LimeLightCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/LimeLightCamera.java
@@ -194,11 +194,11 @@ public class LimeLightCamera extends GenericCamera {
       }
 
       // Save tag IDs to inputs objects
-      input.tagIds =
-          Arrays.stream(LimelightHelpers.getRawFiducials(name))
-              .mapToInt(fiducial -> fiducial.id)
-              .distinct()
-              .toArray();
+      // input.tagIds =
+      //     Arrays.stream(LimelightHelpers.getRawFiducials(name))
+      //         .mapToInt(fiducial -> fiducial.id)
+      //         .distinct()
+      //         .toArray();
     }
   }
 

--- a/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionCamera.java
@@ -38,11 +38,39 @@ public class PhotonVisionCamera extends GenericCamera {
     camera = new PhotonCamera(name);
   }
 
+  /** The empty pipeline result sentinel — avoids allocating a new one each cycle */
+  private static final PhotonPipelineResult EMPTY_RESULT = new PhotonPipelineResult();
+
+  /**
+   * Maximum number of camera frames to process per 20ms loop cycle.
+   *
+   * <p>PhotonVision buffers every frame received since the NT connection was established. On the
+   * very first call to {@code getAllUnreadResults()} (typically ~16 s after boot), that buffer may
+   * contain hundreds of stale frames (16 s × 30 fps = ~480 frames per camera). Processing all of
+   * them in one cycle causes a 115–400 ms first-periodic overrun. By capping the list to the
+   * most-recent MAX_FRAMES_PER_CYCLE entries we limit latency while still receiving all frames that
+   * arrive during a single 20 ms window (≤ 2 at 30 fps).
+   */
+  private static final int MAX_FRAMES_PER_CYCLE = 10;
+
   /** Update the camera and target with the latest result */
   @Override
   public void updateCameraInfo() {
-    camResults = camera.getAllUnreadResults();
-    camResult = camResults.stream().findFirst().orElse(new PhotonPipelineResult());
+    List<PhotonPipelineResult> allResults = camera.getAllUnreadResults();
+    input.unreadResultCount = allResults.size();
+    // Drain stale frames: keep only the most recent MAX_FRAMES_PER_CYCLE results.
+    // This prevents a multi-hundred-millisecond stall on the first periodic() call when
+    // the NT subscriber queue has accumulated hundreds of buffered frames since boot.
+    int size = allResults.size();
+    if (size > MAX_FRAMES_PER_CYCLE) {
+      camResults = allResults.subList(size - MAX_FRAMES_PER_CYCLE, size);
+    } else {
+      camResults = allResults;
+    }
+    input.processedResultCount = camResults.size();
+    input.droppedResultCount = Math.max(0, size - camResults.size());
+    // Avoid stream().findFirst() allocation — use direct index access
+    camResult = camResults.isEmpty() ? EMPTY_RESULT : camResults.get(camResults.size() - 1);
     input.connected = camera.isConnected();
     input.captureTime = camResult.getTimestampSeconds();
   }

--- a/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionPoseCamera.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/PhotonVisionPoseCamera.java
@@ -16,7 +16,6 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotState;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -27,6 +26,7 @@ import org.frc5010.common.vision.VisionConstants;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonPoseEstimator;
 import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
 
 /** A camera using the PhotonVision library. */
 public class PhotonVisionPoseCamera extends PhotonVisionCamera implements FiducialTargetCamera {
@@ -36,6 +36,25 @@ public class PhotonVisionPoseCamera extends PhotonVisionCamera implements Fiduci
   protected Supplier<Pose2d> poseSupplier;
   /** The current list of fiducial IDs */
   protected List<Integer> fiducialIds = new ArrayList<>();
+  /** Pre-allocated list reused each cycle to avoid per-cycle GC pressure */
+  private final List<PoseObservation> observations = new ArrayList<>();
+  /** Pre-allocated set reused each cycle to avoid per-cycle GC pressure */
+  private final Set<Short> tagIds = new HashSet<>();
+  /** Pre-allocated list reused each cycle to avoid per-cycle GC pressure */
+  private final List<PhotonFrameObservation> photonFrameObservations = new ArrayList<>();
+  /**
+   * Pre-allocated output arrays — grown on demand but never shrunk to avoid per-cycle allocation
+   */
+  private PoseObservation[] poseObsArray = new PoseObservation[0];
+
+  private PhotonFrameObservation[] photonFrameObsArray = new PhotonFrameObservation[0];
+
+  private int[] tagIdArray = new int[0];
+
+  /** Sentinel empty Pose3d — returned when no estimate is available; never mutated */
+  private static final Pose3d EMPTY_POSE3D = new Pose3d();
+  /** Pre-allocated stdDev matrix — mutated in getStdDeviations() to avoid per-call allocation */
+  private final Matrix<N3, N1> stdDevMatrix = VecBuilder.fill(0.0, 0.0, 0.0);
 
   /**
    * Constructor
@@ -84,65 +103,70 @@ public class PhotonVisionPoseCamera extends PhotonVisionCamera implements Fiduci
   public void updateCameraInfo() {
     poseEstimator.addHeadingData(Timer.getFPGATimestamp(), poseSupplier.get().getRotation());
 
-    List<PoseObservation> observations = new ArrayList<>();
-    SmartDashboard.putBoolean("Camera/" + name() + "/updating", true);
+    observations.clear();
+    tagIds.clear();
+    photonFrameObservations.clear();
 
     super.updateCameraInfo();
-    Set<Short> tagIds = new HashSet<>();
+
+    double totalTagDistanceAccum = 0.0;
+    double latestAmbiguity = 0.0;
+    Pose3d latestRobotPose = null;
 
     for (PhotonPipelineResult iCamResult : camResults) {
-      SmartDashboard.putBoolean("Camera/" + name() + "/resuls", iCamResult.hasTargets());
-      Optional<EstimatedRobotPose> estimate = poseEstimator.estimateCoprocMultiTagPose(iCamResult);
+      Optional<EstimatedRobotPose> multiTagEstimate =
+          poseEstimator.estimateCoprocMultiTagPose(iCamResult);
+      Optional<EstimatedRobotPose> trigEstimate =
+          poseEstimator.estimatePnpDistanceTrigSolvePose(iCamResult);
 
-      if (estimate.isEmpty() && !DriverStation.isDisabled()) {
-        estimate = poseEstimator.estimatePnpDistanceTrigSolvePose(iCamResult);
+      Optional<EstimatedRobotPose> estimate = Optional.empty();
+      PhotonPoseMethod selectedMethod = PhotonPoseMethod.NONE;
+      if (multiTagEstimate.isPresent()) {
+        estimate = multiTagEstimate;
+        selectedMethod = PhotonPoseMethod.MULTITAG;
+      } else if (trigEstimate.isPresent() && !DriverStation.isDisabled()) {
+        estimate = trigEstimate;
+        selectedMethod = PhotonPoseMethod.TRIG;
       }
 
-      if (estimate.isPresent()) {
-        // if (!DriverStation.isDisabled()) {
-        //   Optional<EstimatedRobotPose> finalEstimate =
-        //       poseEstimator.estimatePnpDistanceTrigSolvePose(iCamResult);
-        //   if (finalEstimate.isPresent()) {
-        //     estimate = finalEstimate;
-        //   }
-        // }
+      double totalTagDistance = 0.0;
+      for (var iTarget : iCamResult.targets) {
+        totalTagDistance += iTarget.bestCameraToTarget.getTranslation().getNorm();
+      }
+      double averageDistance =
+          iCamResult.targets.isEmpty() ? 0.0 : totalTagDistance / iCamResult.targets.size();
 
+      photonFrameObservations.add(
+          new PhotonFrameObservation(
+              iCamResult.getTimestampSeconds(),
+              iCamResult.metadata.getLatencyMillis(),
+              iCamResult.metadata.sequenceID,
+              iCamResult.metadata.publishTimestampMicros,
+              iCamResult.targets.size(),
+              totalTagDistance,
+              toMultitagIdArray(iCamResult),
+              getRawMultitagBestTransform(iCamResult),
+              getRawMultitagAmbiguity(iCamResult),
+              selectedMethod,
+              toPhotonPoseEstimate(multiTagEstimate, iCamResult, totalTagDistance, averageDistance),
+              toPhotonPoseEstimate(trigEstimate, iCamResult, totalTagDistance, averageDistance),
+              toPhotonTargetObservations(iCamResult.targets)));
+
+      if (estimate.isPresent()) {
         EstimatedRobotPose estimatedRobotPose = estimate.get();
         Pose3d robotPose = estimatedRobotPose.estimatedPose;
-
-        double totalTagDistance = 0.0;
-        for (var iTarget : iCamResult.targets) {
-          totalTagDistance += iTarget.bestCameraToTarget.getTranslation().getNorm();
-        }
         // Compute the average tag distance
         int tagCount = estimatedRobotPose.targetsUsed.size();
-        double averageDistance = 0.0;
-        if (!iCamResult.targets.isEmpty()) {
-          averageDistance = totalTagDistance / iCamResult.targets.size();
+
+        // Add tag IDs — use ifPresent to avoid lambda allocation from .map()
+        if (iCamResult.multitagResult.isPresent()) {
+          tagIds.addAll(iCamResult.multitagResult.get().fiducialIDsUsed);
         }
 
-        // Add tag IDs
-        iCamResult.multitagResult.map(it -> tagIds.addAll(it.fiducialIDsUsed));
-
-        SmartDashboard.putNumber(
-            "Camera/" + name() + "/Total Distance To Tag " + name, totalTagDistance);
-        SmartDashboard.putNumber(
-            "Camera/" + name() + "/Photon Ambiguity " + name,
-            iCamResult.getBestTarget().poseAmbiguity);
-        SmartDashboard.putNumberArray(
-            "Camera/" + name() + "/Photon Camera " + name + " POSE",
-            new double[] {
-              robotPose.getX(),
-              robotPose.getY(),
-              robotPose.getRotation().toRotation2d().getDegrees()
-            });
-        SmartDashboard.putNumberArray(
-            "Camera/" + name() + "/Photon Camera " + name + " Robot Offset",
-            new double[] {
-              robotToCamera.getX(),
-              robotToCamera.getY(),
-              robotToCamera.getRotation().toRotation2d().getDegrees()
-            });
+        // Accumulate telemetry for AK logging
+        totalTagDistanceAccum += totalTagDistance;
+        latestAmbiguity = iCamResult.getBestTarget().poseAmbiguity;
+        latestRobotPose = robotPose;
 
         observations.add(
             new PoseObservation(
@@ -155,19 +179,113 @@ public class PhotonVisionPoseCamera extends PhotonVisionCamera implements Fiduci
                 PoseObservationType.PHOTONVISION,
                 ProviderType.FIELD_BASED));
       }
-
-      // Save pose observations to inputs object
-      input.poseObservations = new PoseObservation[observations.size()];
-      for (int i = 0; i < observations.size(); i++) {
-        input.poseObservations[i] = observations.get(i);
-      }
-      // Save tag IDs to inputs objects
-      input.tagIds = new int[tagIds.size()];
-      int i = 0;
-      for (int id : tagIds) {
-        input.tagIds[i++] = id;
-      }
     }
+
+    int frameObsSize = photonFrameObservations.size();
+    if (photonFrameObsArray.length != frameObsSize) {
+      photonFrameObsArray = new PhotonFrameObservation[frameObsSize];
+    }
+    for (int i = 0; i < frameObsSize; i++) {
+      photonFrameObsArray[i] = photonFrameObservations.get(i);
+    }
+    input.photonFrameObservations = photonFrameObsArray;
+
+    // Save pose observations to inputs object (once, outside the loop).
+    // Grow the pre-allocated array only when the size increases; never shrink it.
+    int obsSize = observations.size();
+    if (poseObsArray.length != obsSize) {
+      poseObsArray = new PoseObservation[obsSize];
+    }
+    for (int i = 0; i < obsSize; i++) {
+      poseObsArray[i] = observations.get(i);
+    }
+    input.poseObservations = poseObsArray;
+
+    // Save tag IDs to inputs object (once, outside the loop).
+    int tagCount2 = tagIds.size();
+    if (tagIdArray.length != tagCount2) {
+      tagIdArray = new int[tagCount2];
+    }
+    int i = 0;
+    for (int id : tagIds) {
+      tagIdArray[i++] = id;
+    }
+    // input.tagIds = tagIdArray;
+    // Log telemetry fields via AdvantageKit inputs
+    input.totalTagDistance = totalTagDistanceAccum;
+    input.poseAmbiguity = latestAmbiguity;
+    input.estimatedRobotPose = latestRobotPose != null ? latestRobotPose : EMPTY_POSE3D;
+  }
+
+  private PhotonTargetObservation[] toPhotonTargetObservations(List<PhotonTrackedTarget> targets) {
+    PhotonTargetObservation[] observations = new PhotonTargetObservation[targets.size()];
+    for (int i = 0; i < targets.size(); i++) {
+      PhotonTrackedTarget target = targets.get(i);
+      observations[i] =
+          new PhotonTargetObservation(
+              target.fiducialId,
+              target.yaw,
+              target.pitch,
+              target.area,
+              target.skew,
+              target.poseAmbiguity,
+              target.bestCameraToTarget,
+              target.altCameraToTarget);
+    }
+    return observations;
+  }
+
+  private PhotonPoseEstimate toPhotonPoseEstimate(
+      Optional<EstimatedRobotPose> estimate,
+      PhotonPipelineResult cameraResult,
+      double totalTagDistance,
+      double averageDistance) {
+    if (estimate.isEmpty()) {
+      return PhotonPoseEstimate.EMPTY;
+    }
+
+    EstimatedRobotPose estimatedRobotPose = estimate.get();
+    return new PhotonPoseEstimate(
+        true,
+        estimatedRobotPose.estimatedPose,
+        cameraResult.hasTargets() ? cameraResult.getBestTarget().poseAmbiguity : 0.0,
+        estimatedRobotPose.targetsUsed.size(),
+        averageDistance,
+        toTargetIdArray(estimatedRobotPose.targetsUsed));
+  }
+
+  private int[] toMultitagIdArray(PhotonPipelineResult cameraResult) {
+    if (cameraResult.multitagResult.isEmpty()) {
+      return new int[0];
+    }
+
+    int[] ids = new int[cameraResult.multitagResult.get().fiducialIDsUsed.size()];
+    for (int i = 0; i < ids.length; i++) {
+      ids[i] = cameraResult.multitagResult.get().fiducialIDsUsed.get(i);
+    }
+    return ids;
+  }
+
+  private Transform3d getRawMultitagBestTransform(PhotonPipelineResult cameraResult) {
+    if (cameraResult.multitagResult.isEmpty()) {
+      return new Transform3d();
+    }
+    return cameraResult.multitagResult.get().estimatedPose.best;
+  }
+
+  private double getRawMultitagAmbiguity(PhotonPipelineResult cameraResult) {
+    if (cameraResult.multitagResult.isEmpty()) {
+      return 0.0;
+    }
+    return cameraResult.multitagResult.get().estimatedPose.ambiguity;
+  }
+
+  private int[] toTargetIdArray(List<PhotonTrackedTarget> targets) {
+    int[] ids = new int[targets.size()];
+    for (int i = 0; i < targets.size(); i++) {
+      ids[i] = targets.get(i).fiducialId;
+    }
+    return ids;
   }
 
   @Override
@@ -192,7 +310,10 @@ public class PhotonVisionPoseCamera extends PhotonVisionCamera implements Fiduci
         && observation.tagCount() < 2)) {
       linearStdDev = 100.0;
     }
-    return VecBuilder.fill(linearStdDev, linearStdDev, angularStdDev);
+    stdDevMatrix.set(0, 0, linearStdDev);
+    stdDevMatrix.set(1, 0, linearStdDev);
+    stdDevMatrix.set(2, 0, angularStdDev);
+    return stdDevMatrix;
   }
 
   /**

--- a/src/main/java/org/frc5010/common/sensors/camera/QuestNavInterface.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/QuestNavInterface.java
@@ -26,9 +26,13 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.frc5010.common.drive.GenericDrivetrain;
 import org.frc5010.common.drive.pose.PoseProvider;
+import org.frc5010.common.drive.pose.VisionIOInputsAutoLogged;
 
 /** Add your docs here. */
 public class QuestNavInterface implements PoseProvider {
+
+  /** Per-instance inputs — each QuestNav has its own object */
+  private final VisionIOInputsAutoLogged input = new VisionIOInputsAutoLogged();
 
   private String networkTableRoot = "questnav";
   private Supplier<ChassisSpeeds> robotVelocity = null;
@@ -52,6 +56,13 @@ public class QuestNavInterface implements PoseProvider {
   private Translation2d _calculatedOffsetToRobotCenter = new Translation2d();
   private int _calculatedOffsetToRobotCenterCount = 0;
 
+  /** Reusable observation list — cleared each cycle to avoid per-cycle ArrayList allocation */
+  private final List<PoseObservation> questObservations = new ArrayList<>();
+  /** Grow-only output array — never shrunk to minimise GC pressure */
+  private PoseObservation[] questObsArray = new PoseObservation[0];
+  /** Pre-allocated stdDev matrix — mutated in getStdDeviations() to avoid per-call allocation */
+  private final Matrix<N3, N1> stdDevMatrix = VecBuilder.fill(0.0, 0.0, 0.0);
+
   public QuestNavInterface(Transform3d robotToQuest) {
     super();
     this.robotToQuest = robotToQuest;
@@ -63,6 +74,16 @@ public class QuestNavInterface implements PoseProvider {
     this.robotToQuest = robotToQuest;
     this.networkTableRoot = networkTableRoot;
     this.questNav = new QuestNav();
+  }
+
+  @Override
+  public VisionIOInputsAutoLogged getInput() {
+    return input;
+  }
+
+  @Override
+  public int getCameraIndex() {
+    return 0;
   }
 
   private Pose3d getRobotPoseFromQuestPose(Pose3d questPose) {
@@ -119,14 +140,14 @@ public class QuestNavInterface implements PoseProvider {
       latestPoseFrame = unreadQuestFrames[unreadQuestFrames.length - 1];
     }
 
-    List<PoseObservation> observations = new ArrayList<>();
+    questObservations.clear();
 
     if (initializedPosition) {
       for (PoseFrame frame : unreadQuestFrames) {
         Pose3d robotPose =
             getRobotPoseFromQuestPose(frame.questPose3d()).transformBy(softResetTransform);
         double captureTime = frame.dataTimestamp();
-        observations.add(
+        questObservations.add(
             new PoseObservation(
                 captureTime,
                 robotPose,
@@ -138,11 +159,15 @@ public class QuestNavInterface implements PoseProvider {
       }
     }
     input.connected = isActive();
-    // Save pose observations to inputs object
-    input.poseObservations = new PoseObservation[observations.size()];
-    for (int i = 0; i < observations.size(); i++) {
-      input.poseObservations[i] = observations.get(i);
+    // Save pose observations to inputs object using grow-only pre-allocated array
+    int obsSize = questObservations.size();
+    if (questObsArray.length != obsSize) {
+      questObsArray = new PoseObservation[obsSize];
     }
+    for (int i = 0; i < obsSize; i++) {
+      questObsArray[i] = questObservations.get(i);
+    }
+    input.poseObservations = questObsArray;
   }
 
   @Override
@@ -161,7 +186,10 @@ public class QuestNavInterface implements PoseProvider {
         calib = 10;
       }
     }
-    return VecBuilder.fill(calib, calib, calib * 0.2);
+    stdDevMatrix.set(0, 0, calib);
+    stdDevMatrix.set(1, 0, calib);
+    stdDevMatrix.set(2, 0, calib * 0.2);
+    return stdDevMatrix;
   }
 
   public double getConfidence() {

--- a/src/main/java/org/frc5010/common/sensors/camera/QuestNavOld.java
+++ b/src/main/java/org/frc5010/common/sensors/camera/QuestNavOld.java
@@ -40,10 +40,17 @@ import org.frc5010.common.drive.GenericDrivetrain;
 import org.frc5010.common.drive.pose.DrivePoseEstimator;
 import org.frc5010.common.drive.pose.DrivePoseEstimator.State;
 import org.frc5010.common.drive.pose.PoseProvider;
+import org.frc5010.common.drive.pose.VisionIOInputsAutoLogged;
 import org.frc5010.common.drive.swerve.GenericSwerveDrivetrain;
 
 /** Add your docs here. */
 public class QuestNavOld implements PoseProvider {
+  /** Per-instance inputs — each QuestNav has its own object */
+  private final VisionIOInputsAutoLogged input = new VisionIOInputsAutoLogged();
+  /** Per-instance disconnected alert */
+  private final edu.wpi.first.wpilibj.Alert disconnectedAlert =
+      new edu.wpi.first.wpilibj.Alert("QuestNav", edu.wpi.first.wpilibj.Alert.AlertType.kWarning);
+
   private boolean initializedPosition = false;
   public static boolean isActive = false;
   private String networkTableRoot = "questnav";
@@ -113,6 +120,16 @@ public class QuestNavOld implements PoseProvider {
     this.networkTableRoot = networkTableRoot;
     setupNetworkTables(networkTableRoot);
     setupInitialTimestamp();
+  }
+
+  @Override
+  public VisionIOInputsAutoLogged getInput() {
+    return input;
+  }
+
+  @Override
+  public int getCameraIndex() {
+    return 0;
   }
 
   private void setupInitialTimestamp() {

--- a/src/main/java/org/frc5010/common/subsystems/CameraSystem.java
+++ b/src/main/java/org/frc5010/common/subsystems/CameraSystem.java
@@ -54,6 +54,10 @@ public abstract class CameraSystem extends GenericSubsystem {
   protected TargetModel targetModel = new TargetModel(0.3556);
   /** Whether to view game pieces in simulation */
   protected boolean viewGamePieces = true;
+  /** Cached game piece A list to detect changes between cycles */
+  private List<Pose3d> cachedGpas = List.of();
+  /** Cached game piece B list to detect changes between cycles */
+  private List<Pose3d> cachedGpbs = List.of();
 
   /**
    * Creates a new CameraSystem with the specified camera.
@@ -88,25 +92,31 @@ public abstract class CameraSystem extends GenericSubsystem {
     if (!camera.canViewGamePieces()) {
       return;
     }
-    // Update game piece A targets in simulation
+    // Update game piece A targets only when the list has changed
     List<Pose3d> gpas =
         SimulatedArena.getInstance().getGamePiecesByType(Constants.Simulation.gamePieceA).stream()
             .map(it -> it.getPose3d())
             .collect(Collectors.toList());
-    SimulatedCamera.visionSim.removeVisionTargets("GPA");
-    for (Pose3d gpa : gpas) {
-      VisionTargetSim simTarget = new VisionTargetSim(gpa, targetModel);
-      SimulatedCamera.visionSim.addVisionTargets("GPA", simTarget);
+    if (!gpas.equals(cachedGpas)) {
+      cachedGpas = gpas;
+      SimulatedCamera.visionSim.removeVisionTargets("GPA");
+      for (Pose3d gpa : gpas) {
+        VisionTargetSim simTarget = new VisionTargetSim(gpa, targetModel);
+        SimulatedCamera.visionSim.addVisionTargets("GPA", simTarget);
+      }
     }
-    // Update game piece B targets in simulation
+    // Update game piece B targets only when the list has changed
     List<Pose3d> gpbs =
         SimulatedArena.getInstance().getGamePiecesByType(Constants.Simulation.gamePieceB).stream()
             .map(it -> it.getPose3d())
             .collect(Collectors.toList());
-    SimulatedCamera.visionSim.removeVisionTargets("GPB");
-    for (Pose3d gpb : gpbs) {
-      VisionTargetSim simTarget = new VisionTargetSim(gpb, targetModel);
-      SimulatedCamera.visionSim.addVisionTargets("GPB", simTarget);
+    if (!gpbs.equals(cachedGpbs)) {
+      cachedGpbs = gpbs;
+      SimulatedCamera.visionSim.removeVisionTargets("GPB");
+      for (Pose3d gpb : gpbs) {
+        VisionTargetSim simTarget = new VisionTargetSim(gpb, targetModel);
+        SimulatedCamera.visionSim.addVisionTargets("GPB", simTarget);
+      }
     }
   }
 

--- a/src/main/java/org/frc5010/common/utils/OrchestraManager.java
+++ b/src/main/java/org/frc5010/common/utils/OrchestraManager.java
@@ -1,0 +1,92 @@
+package org.frc5010.common.utils;
+
+import com.ctre.phoenix6.CANBus;
+import com.ctre.phoenix6.Orchestra;
+import com.ctre.phoenix6.StatusCode;
+import com.ctre.phoenix6.configs.AudioConfigs;
+import com.ctre.phoenix6.hardware.TalonFX;
+import edu.wpi.first.wpilibj.Filesystem;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.frc5010.common.config.json.devices.OrchestraConfigJson;
+
+/** Manages CTRE Orchestra playback through all robot TalonFX motors during disabled mode. */
+public class OrchestraManager {
+  private static Orchestra orchestra;
+  private static Map<String, String> musicMap;
+  private static OrchestraConfigJson musicConfigJson;
+  private static List<TalonFX> motors = new ArrayList<>();
+
+  public static void init(OrchestraConfigJson configJson) {
+    orchestra = new Orchestra();
+    musicMap = new HashMap<>();
+    musicConfigJson = configJson;
+    for (OrchestraConfigJson.MusicEntry entry : musicConfigJson.music) {
+      musicMap.put(entry.name, entry.path);
+    }
+  }
+
+  public static void loadMusic(String musicFileName) {
+    if (null != orchestra) {
+      motors.clear();
+      for (int id : musicConfigJson.rioIds) {
+        TalonFX motor = new TalonFX(id);
+        AudioConfigs config = new AudioConfigs().withAllowMusicDurDisable(true);
+        motor.getConfigurator().apply(config, 0);
+        orchestra.addInstrument(motor);
+        motors.add(motor);
+      }
+      CANBus canivoreBus = new CANBus("canivore");
+      for (int id : musicConfigJson.canivoreIds) {
+        TalonFX motor = new TalonFX(id, canivoreBus);
+        AudioConfigs config = new AudioConfigs().withAllowMusicDurDisable(true);
+        motor.getConfigurator().apply(config, 0);
+        orchestra.addInstrument(motor, 0);
+        motors.add(motor);
+      }
+      orchestra.loadMusic(
+          Filesystem.getDeployDirectory().toPath().resolve(musicMap.get(musicFileName)).toString());
+    }
+  }
+
+  /** Start playing the mariachi song. Safe to call repeatedly. */
+  public static void play() {
+    if (null != orchestra) {
+      StatusCode status = orchestra.play();
+      if (!status.isOK()) {
+        System.err.println("Failed to play music: " + status);
+      }
+    }
+  }
+
+  public static boolean isPlaying() {
+    return null != orchestra && orchestra.isPlaying();
+  }
+
+  /** Stop playback and release motors back to normal control. */
+  public static void stop() {
+    if (null != orchestra) {
+      orchestra.stop();
+    }
+  }
+
+  public static void playTone(double frequencyHz) {
+    if (motors != null) {
+      com.ctre.phoenix6.controls.MusicTone tone =
+          new com.ctre.phoenix6.controls.MusicTone(frequencyHz);
+      for (TalonFX motor : motors) {
+        motor.setControl(tone);
+      }
+    }
+  }
+
+  public static void stopTone() {
+    if (motors != null) {
+      for (TalonFX motor : motors) {
+        motor.setControl(new com.ctre.phoenix6.controls.NeutralOut());
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add Orchestra JSON/device parser and OrchestraConfig (OrchestraParser, OrchestraConfigJson) and hook it into RobotParser; add OrchestraManager init call. Major refactor and performance work across pose estimation and swerve drive: replace allocation-heavy streams with indexed loops, preallocate reusable buffers/arrays (pose3d array, vision diagnostics, odometry buffers, module info), convert GenericSwerveModuleInfo from record to mutable class with update(...) methods, and reduce per-cycle object allocations. Improve DrivePoseEstimator and PoseProvider: add typed vision diagnostics, rejection reasons, richer per-camera inputs, zero-allocation getObservationsArray(), stronger logging (AutoLog/Logger) and tightened rejection logic. Akit swerve changes: switch closed-loop outputs to TorqueCurrentFOC, add current limits to TalonFX config, add a runVelocity overload that accepts per-module Current[] (preserves no-arg wrapper), add torque-current feedforward characterization command, preallocate odometry arrays, and log empty setpoints via sentinel. Misc fixes: increase PID_TUNING_VOLTAGE, comment out duplicated WpiDataLogging.start, add GenericRobot.hasEverEnabled(), add GenericSubsystem.setHeight stub, PathPlanner warmup moved into drivetrain init, and several small telemetry/field-access adjustments. Note: these changes introduce API breaks (PoseProvider interface now requires per-instance getInput()/getCameraIndex(), GenericSwerveModuleInfo is now mutable, runVelocity signature changed), so implementers must update custom providers/drivetrain code accordingly.