### PR TITLE
Rewrite Driver and Operator controls

### DIFF
--- a/src/main/java/frc/robot/rebuilt/Constants.java
+++ b/src/main/java/frc/robot/rebuilt/Constants.java
@@ -28,6 +28,12 @@ public class Constants {
     /** Time the hood current must stay above the stall threshold, to ignore startup inrush. */
     public static final double HOOD_STALL_DEBOUNCE_SECONDS = 0.2;
 
+    public static final double TURRET_STALL_CURRENT_THRESHOLD = 20.0;
+    /** Duty cycle used to slowly run the turret CCW toward the hard stop while zeroing. */
+    public static final double TURRET_ZEROING_DUTY_CYCLE = 0.10;
+    /** Time the turret current must stay above the stall threshold, to ignore startup inrush. */
+    public static final double TURRET_STALL_DEBOUNCE_SECONDS = 0.2;
+
     public static final double HOOD_LEGACY_START_ANGLE_DEGREES = 30.0;
     public static final double HOOD_CORRECTED_START_ANGLE_DEGREES = 12.723;
     public static final double HOOD_CORRECTED_END_ANGLE_DEGREES = 45.723;
@@ -56,6 +62,8 @@ public class Constants {
     public static final double SPINDEXER_SPEED = 0.90;
     public static final double TRANSFER_SPEED = 1.0;
     public static final double TRANSFER_CHURN = 0.25;
+    /** Deadzone for the operator sticks that manually run the spindexer and transfer. */
+    public static final double OPERATOR_STICK_DEADZONE = 0.1;
   }
 
   public static class Intake {

--- a/src/main/java/frc/robot/rebuilt/Rebuilt.java
+++ b/src/main/java/frc/robot/rebuilt/Rebuilt.java
@@ -64,10 +64,6 @@ public class Rebuilt extends GenericRobot {
     autocommands = new AutoCommands(subsystems);
     // OrchestraManager.loadMusic("raiders");
     RobotController.setBrownoutVoltage(Volts.of(4.6));
-
-    if (operator.isPresent()) {
-      operator.get().createStartButton().onTrue(launcher.zeroTurretCommand());
-    }
   }
 
   @Override

--- a/src/main/java/frc/robot/rebuilt/commands/IndexerCommands.java
+++ b/src/main/java/frc/robot/rebuilt/commands/IndexerCommands.java
@@ -7,6 +7,7 @@ import frc.robot.rebuilt.Constants;
 import frc.robot.rebuilt.subsystems.Indexer.Indexer;
 import frc.robot.rebuilt.subsystems.Launcher.Launcher;
 import java.util.Map;
+import java.util.function.DoubleSupplier;
 import org.frc5010.common.arch.GenericSubsystem;
 import org.frc5010.common.config.ConfigConstants;
 import org.frc5010.common.sensors.Controller;
@@ -46,6 +47,36 @@ public class IndexerCommands {
             Commands.either(
                 shouldForceCommand(), shouldChurnCommand(), () -> launcher.isOKToFire()))
         .onFalse(shouldChurnCommand());
+
+    // Manual operator control: left stick Y runs the spindexer, right stick Y runs the
+    // transfer, proportionally in either direction. Active only while a stick is outside
+    // its deadzone; an indexer state request fired meanwhile interrupts manual control.
+    operator.setLeftYAxis(
+        operator.createLeftYAxis().negate().deadzone(Constants.Indexer.OPERATOR_STICK_DEADZONE));
+    operator.setRightYAxis(
+        operator.createRightYAxis().negate().deadzone(Constants.Indexer.OPERATOR_STICK_DEADZONE));
+    new Trigger(() -> operator.getLeftYAxis() != 0.0 || operator.getRightYAxis() != 0.0)
+        .whileTrue(manualIndexerCommand(operator::getLeftYAxis, operator::getRightYAxis));
+  }
+
+  /**
+   * Runs the spindexer and transfer directly from the supplied speeds until interrupted, then
+   * stops both and returns the indexer to IDLE.
+   */
+  public static Command manualIndexerCommand(
+      DoubleSupplier spindexerSpeed, DoubleSupplier transferSpeed) {
+    return Commands.run(
+            () -> {
+              indexer.runSpindexer(spindexerSpeed.getAsDouble());
+              indexer.runTransferFront(transferSpeed.getAsDouble());
+            },
+            indexer)
+        .finallyDo(
+            () -> {
+              indexer.runSpindexer(0);
+              indexer.runTransferFront(0);
+              indexer.setCurrentState(IndexerState.IDLE);
+            });
   }
 
   private void configureTriggerStates() {

--- a/src/main/java/frc/robot/rebuilt/commands/IntakeCommands.java
+++ b/src/main/java/frc/robot/rebuilt/commands/IntakeCommands.java
@@ -5,6 +5,7 @@ import static edu.wpi.first.units.Units.Degrees;
 import edu.wpi.first.wpilibj.RobotState;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.ScheduleCommand;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.rebuilt.Constants;
 import frc.robot.rebuilt.subsystems.intake.Intake;
@@ -118,10 +119,13 @@ public class IntakeCommands {
     leftTrigger.onTrue(shouldIntaking());
 
     controller.createRightBumper().onTrue(shouldRetracting());
-    operator.createStartButton().onTrue(Commands.run(() -> intake.setHopperRetracted()));
-    operator.createBackButton().onTrue(Commands.run(() -> intake.setHopperDeployed()));
 
     controller.createXButton().onTrue(operatorHopperDownCommand());
+
+    // Hold to run the hopper into its deploy hard stop; when the stall is debounced the
+    // hopper re-zeros and the operator controller rumbles. Releasing before the stall
+    // aborts without re-zeroing.
+    operator.createXButton().whileTrue(rezeroHopperCommand(operator));
     // operator.createRightBumper().onTrue(shouldAngled()).onFalse(shouldIntaking());
 
     intakeSpeedSupplier =
@@ -269,6 +273,29 @@ public class IntakeCommands {
                 .until(hopperHardStopped::getAsBoolean)
                 .withTimeout(1.5))
         .andThen(Commands.runOnce(() -> intake.runHopper(0)));
+  }
+
+  /**
+   * Operator hold-to-re-zero: drives the hopper into its deploy hard stop until the stall is
+   * debounced, then unconditionally re-zeros the hopper (even if it was already marked zeroed)
+   * and rumbles the given controller. Releasing early stops the hopper without re-zeroing.
+   */
+  public static Command rezeroHopperCommand(Controller rumbleController) {
+    Trigger hopperHardStopped =
+        new Trigger(() -> intake.isHopperHardStopDetected())
+            .debounce(Constants.Intake.HOPPER_STALL_TIME);
+
+    return Commands.run(() -> intake.runHopper(Constants.Intake.HOPPER_FIRST_DEPLOY_DUTY), intake)
+        .until(hopperHardStopped::getAsBoolean)
+        .andThen(
+            Commands.runOnce(
+                () -> {
+                  intake.runHopper(0);
+                  markHopperZeroed();
+                  intake.setCurrentState(IntakeState.DEPLOYED);
+                }))
+        .andThen(new ScheduleCommand(rumbleController.rumblePulseCommand(1.0, 0.5)))
+        .finallyDo(() -> intake.runHopper(0));
   }
 
   private static Command homeUnzeroedHopperCommand() {

--- a/src/main/java/frc/robot/rebuilt/commands/LauncherCommands.java
+++ b/src/main/java/frc/robot/rebuilt/commands/LauncherCommands.java
@@ -4,7 +4,6 @@ import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.Radians;
-import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -13,9 +12,11 @@ import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.ScheduleCommand;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.rebuilt.Constants;
 import frc.robot.rebuilt.FieldConstants;
@@ -210,20 +211,15 @@ public class LauncherCommands {
 
     operator.createAButton().whileTrue(towerPresetStateCommand()).onFalse(shouldLowCommand());
 
-    operator
-        .createBButton()
-        .whileTrue(rightCornerPresetStateCommandr())
-        .onFalse(shouldLowCommand());
-
-    operator.createXButton().whileTrue(leftCornerPresetStateCommand()).onFalse(shouldLowCommand());
+    // Hold to slowly sweep the turret CCW into its hard stop, then the turret angle resets
+    // to the hard-stop value and the operator controller rumbles. Releasing before the
+    // stall aborts without re-zeroing.
+    operator.createBButton().whileTrue(zeroTurretOnStallSequence(operator));
 
     // Hold to slowly run the hood down until it stalls against the hard stop, then the
-    // hood position resets to its minimum. Releasing before the stall aborts without zeroing.
-    // (This replaced the turret-forward preset, which is still available as the
-    // "towerForwardPreset" named command.)
-    operator.createYButton().whileTrue(zeroHoodOnStallSequence());
-
-    operator.createBackButton().whileTrue(zeroHoodSequence());
+    // hood position resets to its minimum and the operator controller rumbles. Releasing
+    // before the stall aborts without zeroing.
+    operator.createYButton().whileTrue(zeroHoodOnStallSequence(operator));
 
     // This allowed auto-hammer time
     // Trigger isTrenchTrigger = new Trigger(() -> launcher.isNearTrench());
@@ -471,12 +467,13 @@ public class LauncherCommands {
    * debounce period so the startup inrush doesn't trigger a false zero. If the command is
    * interrupted before the stall is detected, the hood stops without re-zeroing.
    */
-  public static Command zeroHoodOnStallSequence() {
+  public static Command zeroHoodOnStallSequence(Controller rumbleController) {
     Debouncer stallDebouncer = new Debouncer(Constants.Launcher.HOOD_STALL_DEBOUNCE_SECONDS);
     return Commands.run(() -> launcher.runHoodDownSlowly())
         .until(() -> stallDebouncer.calculate(launcher.isHoodStalled()))
         .andThen(Commands.runOnce(() -> launcher.stopHood()))
         .andThen(Commands.runOnce(() -> launcher.zeroHood()))
+        .andThen(new ScheduleCommand(rumbleController.rumblePulseCommand(1.0, 0.5)))
         .andThen(
             Commands.run(
                     () -> {
@@ -498,24 +495,49 @@ public class LauncherCommands {
             });
   }
 
-  public static Command zeroHoodSequence() {
-    return Commands.run(() -> launcher.runHoodDown())
-        .withTimeout(Seconds.of(0.75))
-        .andThen(Commands.runOnce(() -> launcher.stopHood()))
-        .andThen(Commands.runOnce(() -> launcher.zeroHood()))
+  /**
+   * Slowly sweeps the turret toward its hard stop until the motor current spikes, then resets the
+   * turret angle to the hard-stop value and rumbles the operator's controller. The turret's
+   * closed-loop controller and firmware soft limits are suspended for the sweep and always
+   * restored afterward. If the command is interrupted before the stall is detected, the turret
+   * stops without re-zeroing. Only runs in teleop while enabled and with the intake deployed
+   * (the retracted hopper arm interferes with turret rotation).
+   */
+  public static Command zeroTurretOnStallSequence(Controller rumbleController) {
+    Debouncer stallDebouncer = new Debouncer(Constants.Launcher.TURRET_STALL_DEBOUNCE_SECONDS);
+    return Commands.run(() -> launcher.runTurretTowardHardStop(), launcher)
+        .until(() -> stallDebouncer.calculate(launcher.isTurretStalled()))
+        .andThen(
+            Commands.runOnce(
+                () -> {
+                  launcher.stopTurret();
+                  launcher.zeroTurret();
+                }))
+        .andThen(new ScheduleCommand(rumbleController.rumblePulseCommand(1.0, 0.5)))
         .andThen(
             Commands.run(
                     () -> {
-                      org.frc5010.common.subsystems.LEDStrip.changeSegmentPattern(
-                          org.frc5010.common.config.ConfigConstants.ALL_LEDS,
-                          org.frc5010.common.subsystems.LEDStrip.getRainbowPattern(50.0));
+                      LEDStrip.changeSegmentPattern(
+                          ConfigConstants.ALL_LEDS, LEDStrip.getRainbowPattern(50.0));
                     })
                 .withTimeout(0.5)
                 .ignoringDisable(true))
-        .beforeStarting(() -> frc.robot.rebuilt.Rebuilt.isZeroingBurst = true)
+        .beforeStarting(
+            () -> {
+              stallDebouncer.calculate(false);
+              frc.robot.rebuilt.Rebuilt.isZeroingBurst = true;
+              launcher.beginTurretZeroing();
+            })
         .finallyDo(
             () -> {
+              launcher.stopTurret();
+              launcher.endTurretZeroing();
               frc.robot.rebuilt.Rebuilt.isZeroingBurst = false;
-            });
+            })
+        .onlyIf(
+            () ->
+                DriverStation.isTeleopEnabled()
+                    && !intake.isCurrent(IntakeState.RETRACTING)
+                    && !intake.isCurrent(IntakeState.RETRACTED));
   }
 }

--- a/src/main/java/frc/robot/rebuilt/subsystems/Launcher/Launcher.java
+++ b/src/main/java/frc/robot/rebuilt/subsystems/Launcher/Launcher.java
@@ -417,10 +417,6 @@ public class Launcher extends GenericSubsystem {
         });
   }
 
-  public void runHoodDown() {
-    io.runHoodDown();
-  }
-
   public void runHoodDownSlowly() {
     io.runHoodDownSlowly();
   }
@@ -451,6 +447,26 @@ public class Launcher extends GenericSubsystem {
 
   public void zeroTurret() {
     io.zeroTurret();
+  }
+
+  public void beginTurretZeroing() {
+    io.beginTurretZeroing();
+  }
+
+  public void runTurretTowardHardStop() {
+    io.runTurretTowardHardStop();
+  }
+
+  public void stopTurret() {
+    io.stopTurret();
+  }
+
+  public boolean isTurretStalled() {
+    return io.isTurretStalled();
+  }
+
+  public void endTurretZeroing() {
+    io.endTurretZeroing();
   }
 
   public boolean isTurretAtZero() {

--- a/src/main/java/frc/robot/rebuilt/subsystems/Launcher/LauncherIO.java
+++ b/src/main/java/frc/robot/rebuilt/subsystems/Launcher/LauncherIO.java
@@ -131,8 +131,6 @@ public interface LauncherIO {
 
   public Command getTurretSysIdCommand(GenericSubsystem launcher);
 
-  public void runHoodDown();
-
   public void runHoodDownSlowly();
 
   public void stopHood();
@@ -179,6 +177,23 @@ public interface LauncherIO {
   }
 
   public void zeroTurret();
+
+  /** Prepares the turret for open-loop zeroing: suspends closed-loop control and soft limits. */
+  public default void beginTurretZeroing() {}
+
+  /** Runs the turret open-loop toward its hard stop for zeroing. */
+  public default void runTurretTowardHardStop() {}
+
+  /** Stops open-loop turret motion. */
+  public default void stopTurret() {}
+
+  /** Whether the turret motor current indicates it is stalled against the hard stop. */
+  public default boolean isTurretStalled() {
+    return false;
+  }
+
+  /** Restores turret soft limits and re-syncs the closed-loop controller after zeroing. */
+  public default void endTurretZeroing() {}
 
   public default boolean isTurretAtZero() {
     return false;

--- a/src/main/java/frc/robot/rebuilt/subsystems/Launcher/LauncherIOReal.java
+++ b/src/main/java/frc/robot/rebuilt/subsystems/Launcher/LauncherIOReal.java
@@ -18,6 +18,7 @@ import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.CANBus;
+import com.ctre.phoenix6.configs.SoftwareLimitSwitchConfigs;
 import com.ctre.phoenix6.controls.MotionMagicTorqueCurrentFOC;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.TalonFX;
@@ -479,10 +480,6 @@ public class LauncherIOReal implements LauncherIO { // -0.030679615757712823
     LEDStrip.changeSegmentPattern(ConfigConstants.ALL_LEDS, LEDStrip.getSolidPattern(Color.kGreen));
   }
 
-  public void runHoodDown() {
-    hood.getMotor().setDutyCycle(-1.0);
-  }
-
   public void runHoodDownSlowly() {
     hood.getMotor().setDutyCycle(Constants.Launcher.HOOD_ZEROING_DUTY_CYCLE);
   }
@@ -834,6 +831,49 @@ public class LauncherIOReal implements LauncherIO { // -0.030679615757712823
   @Override
   public void zeroTurret() {
     turret.getMotor().setEncoderPosition(HARD_STOP);
+  }
+
+  @Override
+  public void beginTurretZeroing() {
+    if (smartTurretController != null) {
+      smartTurretController.stop();
+      // Lift both firmware soft limits: a mis-zeroed encoder (the reason for re-zeroing)
+      // can read anywhere, so either limit could block the sweep to the hard stop.
+      setTurretSoftLimitsEnabled(false);
+    }
+  }
+
+  @Override
+  public void runTurretTowardHardStop() {
+    turret.getMotor().setDutyCycle(Constants.Launcher.TURRET_ZEROING_DUTY_CYCLE);
+  }
+
+  @Override
+  public void stopTurret() {
+    turret.getMotor().setDutyCycle(0.0);
+  }
+
+  @Override
+  public boolean isTurretStalled() {
+    return Math.abs(turret.getMotor().getStatorCurrent().in(Amps))
+        > Constants.Launcher.TURRET_STALL_CURRENT_THRESHOLD;
+  }
+
+  @Override
+  public void endTurretZeroing() {
+    if (smartTurretController != null) {
+      setTurretSoftLimitsEnabled(true);
+      smartTurretController.reset(turret.getAngle().in(Rotations), 0);
+    }
+  }
+
+  private void setTurretSoftLimitsEnabled(boolean enabled) {
+    TalonFX talon = smartTurretController.getTalonFX();
+    SoftwareLimitSwitchConfigs limits = new SoftwareLimitSwitchConfigs();
+    talon.getConfigurator().refresh(limits);
+    limits.ForwardSoftLimitEnable = enabled;
+    limits.ReverseSoftLimitEnable = enabled;
+    talon.getConfigurator().apply(limits);
   }
 
   @Override

--- a/src/main/java/org/frc5010/common/sensors/Controller.java
+++ b/src/main/java/org/frc5010/common/sensors/Controller.java
@@ -8,6 +8,8 @@ import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.wpilibj.GenericHID.HIDType;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.button.POVButton;
 import java.util.HashMap;
@@ -353,6 +355,21 @@ public class Controller {
    */
   public void setRumble(double power) {
     joystick.setRumble(RumbleType.kBothRumble, power);
+  }
+
+  /**
+   * Creates a command that rumbles the controller at the given power for the given duration, then
+   * stops. Schedule it separately (e.g. via ScheduleCommand) if it must outlive the command that
+   * triggered it.
+   *
+   * @param power the rumble power [0, 1]
+   * @param seconds how long to rumble
+   * @return the rumble pulse command
+   */
+  public Command rumblePulseCommand(double power, double seconds) {
+    return Commands.startEnd(() -> setRumble(power), () -> setRumble(0))
+        .withTimeout(seconds)
+        .ignoringDisable(true);
   }
 
   /**


### PR DESCRIPTION
…icks

Operator button layout:
- Y (hold): zero hood on stall (now rumbles the operator controller on completion)
- X (hold): re-zero hopper by driving into the deploy hard stop until the stall debounces, then reset the zero and rumble (replaces the left-corner preset binding)
- B (hold): new stall-based turret zero — sweeps the turret CCW into its hard stop with soft limits lifted, resets the angle to the hard-stop value, restores limits, re-syncs the smart controller, and rumbles (replaces the right-corner preset binding)
- Left stick Y / right stick Y: manual proportional spindexer / transfer control in both directions outside a deadzone
- START/BACK bindings removed (turret encoder reset, hopper deploy/retract requests, timed hood zero)

Supporting changes:
- Controller.rumblePulseCommand() helper for timed rumble pulses
- Turret zeroing IO plumbing (begin/run/stop/isStalled/end) in LauncherIO, LauncherIOReal, and Launcher, with tunable stall constants
- Removed the dead timed zeroHoodSequence and runHoodDown chain

Needs on-robot verification: turret zeroing duty sign and stall current threshold, hopper-vs-turret clearance at the hard stop, and manual stick directions.


Claude-Session: https://claude.ai/code/session_01KiqYLRGPrwjGe5JiAhPd5Z